### PR TITLE
feat: add Google Sheets range link copy functionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -813,7 +813,6 @@
       "integrity": "sha512-vnDVpYPMzs4wunl27jHrfmwojOGKya0xyM3sH+UE5iv5uPS6vX7UIoh6m+vQc5LGBq52HBKPIn/zcSZVzeDEZg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -925,7 +924,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -33,7 +33,7 @@
     "message": "Link to this range copied to clipboard"
   },
   "copyGoogleSheetsRangeFailure": {
-    "message": "Failed to copy selected range link to clipboard"
+    "message": "Failed to copy link to the selected range to clipboard"
   },
   "settingsTitle": {
     "message": "Settings"

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -30,7 +30,7 @@
     "message": "Copy Google Sheets range link with Slack emoji"
   },
   "copyGoogleSheetsRangeSuccess": {
-    "message": "Selected range link copied to clipboard"
+    "message": "Link to this range copied to clipboard"
   },
   "copyGoogleSheetsRangeFailure": {
     "message": "Failed to copy selected range link to clipboard"

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -27,7 +27,7 @@
     "message": "Failed to copy link to clipboard"
   },
   "copyGoogleSheetsRangeDescription": {
-    "message": "Copy Google Sheets selected range link with Slack emoji"
+    "message": "Copy Google Sheets range link with Slack emoji"
   },
   "copyGoogleSheetsRangeSuccess": {
     "message": "Selected range link copied to clipboard"

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -26,6 +26,15 @@
   "copyLinkFailure": {
     "message": "Failed to copy link to clipboard"
   },
+  "copyGoogleSheetsRangeDescription": {
+    "message": "Copy Google Sheets selected range link with Slack emoji"
+  },
+  "copyGoogleSheetsRangeSuccess": {
+    "message": "Selected range link copied to clipboard"
+  },
+  "copyGoogleSheetsRangeFailure": {
+    "message": "Failed to copy selected range link to clipboard"
+  },
   "settingsTitle": {
     "message": "Settings"
   },

--- a/public/_locales/ja/messages.json
+++ b/public/_locales/ja/messages.json
@@ -30,7 +30,7 @@
     "message": "Google スプレッドシートの選択した範囲のリンクを Slack 絵文字つきでコピー"
   },
   "copyGoogleSheetsRangeSuccess": {
-    "message": "選択した範囲のリンクをクリップボードにコピーしました"
+    "message": "この範囲のリンクをクリップボードにコピーしました"
   },
   "copyGoogleSheetsRangeFailure": {
     "message": "選択した範囲のリンクのコピーに失敗しました"

--- a/public/_locales/ja/messages.json
+++ b/public/_locales/ja/messages.json
@@ -26,6 +26,15 @@
   "copyLinkFailure": {
     "message": "リンクのコピーに失敗しました"
   },
+  "copyGoogleSheetsRangeDescription": {
+    "message": "Google スプレッドシートの選択した範囲のリンクを Slack 絵文字つきでコピー"
+  },
+  "copyGoogleSheetsRangeSuccess": {
+    "message": "選択した範囲のリンクをクリップボードにコピーしました"
+  },
+  "copyGoogleSheetsRangeFailure": {
+    "message": "選択した範囲のリンクのコピーに失敗しました"
+  },
   "settingsTitle": {
     "message": "設定"
   },

--- a/public/_locales/zh_CN/messages.json
+++ b/public/_locales/zh_CN/messages.json
@@ -30,7 +30,7 @@
     "message": "复制Google表格范围链接（带Slack表情）"
   },
   "copyGoogleSheetsRangeSuccess": {
-    "message": "Google表格范围链接已复制到剪贴板"
+    "message": "指向此范围的链接已复制到剪贴板"
   },
   "copyGoogleSheetsRangeFailure": {
     "message": "复制Google表格范围链接到剪贴板失败"

--- a/public/_locales/zh_CN/messages.json
+++ b/public/_locales/zh_CN/messages.json
@@ -26,6 +26,15 @@
   "copyLinkFailure": {
     "message": "复制链接到剪贴板失败"
   },
+  "copyGoogleSheetsRangeDescription": {
+    "message": "复制Google表格范围链接（带Slack表情）"
+  },
+  "copyGoogleSheetsRangeSuccess": {
+    "message": "Google表格范围链接已复制到剪贴板"
+  },
+  "copyGoogleSheetsRangeFailure": {
+    "message": "复制Google表格范围链接到剪贴板失败"
+  },
   "settingsTitle": {
     "message": "设置"
   },

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -52,6 +52,13 @@
         "mac": "MacCtrl+T"
       },
       "description": "__MSG_copyTitleDescription__"
+    },
+    "copy-google-sheets-range": {
+      "suggested_key": {
+        "default": "Alt+R",
+        "mac": "MacCtrl+R"
+      },
+      "description": "__MSG_copyGoogleSheetsRangeDescription__"
     }
   },
   "background": {

--- a/public/manifest_firefox.json
+++ b/public/manifest_firefox.json
@@ -14,18 +14,11 @@
   "browser_specific_settings": {
     "gecko": {
       "id": "copylink-dev@example.com",
-        "strict_min_version": "127.0"
+      "strict_min_version": "127.0"
     }
   },
-  "permissions": [
-    "activeTab",
-    "scripting",
-    "storage",
-    "clipboardWrite"
-  ],
-  "web_accessible_resources": [
-    "styles/toast.css"
-  ],
+  "permissions": ["activeTab", "scripting", "storage", "clipboardWrite"],
+  "web_accessible_resources": ["styles/toast.css"],
   "browser_action": {
     "default_popup": "popup.html",
     "default_icon": {
@@ -56,6 +49,13 @@
         "mac": "MacCtrl+T"
       },
       "description": "__MSG_copyTitleDescription__"
+    },
+    "copy-google-sheets-range": {
+      "suggested_key": {
+        "default": "Alt+R",
+        "mac": "MacCtrl+R"
+      },
+      "description": "__MSG_copyGoogleSheetsRangeDescription__"
     }
   },
   "background": {

--- a/src/scripts/content.ts
+++ b/src/scripts/content.ts
@@ -12,6 +12,7 @@ const getValidCommands = () =>
     COPY_LINK: "copy-link",
     COPY_LINK_FOR_SLACK: "copy-link-for-slack",
     COPY_TITLE: "copy-title",
+    COPY_GOOGLE_SHEETS_RANGE: "copy-google-sheets-range",
   } as const);
 
 const isValidCommand = (command: string): command is Command => {

--- a/src/scripts/copyTextLink.ts
+++ b/src/scripts/copyTextLink.ts
@@ -135,18 +135,11 @@ export const copyTextLink = async (command: Command) => {
     const linkText = sheetTitle;
     const text = `${emojiName} ${linkText}`;
     const html = `${emojiName}&nbsp;<a href="${rangeInfo.link}">${linkText}</a>&nbsp;`;
-    const fallbackElement = document.createElement("span");
-    fallbackElement.appendChild(document.createTextNode(`${emojiName} `));
-    const anchor = document.createElement("a");
-    anchor.setAttribute("href", rangeInfo.link);
-    anchor.textContent = linkText;
-    fallbackElement.appendChild(anchor);
     await copyToClipboard(
       text,
       t("copyGoogleSheetsRangeSuccess"),
       t("copyGoogleSheetsRangeFailure"),
       html,
-      fallbackElement
     );
   };
 

--- a/src/scripts/copyTextLink.ts
+++ b/src/scripts/copyTextLink.ts
@@ -1,5 +1,6 @@
 import { getFormattedTitle } from "./getFormattedTitle";
 import { getEmojiName } from "./getEmojiName";
+import { getGoogleSheetsRangeInfo } from "./getGoogleSheetsRangeLink";
 import { showToast } from "../utils/toast";
 import type { Command } from "../types/types";
 
@@ -123,10 +124,37 @@ export const copyTextLink = async (command: Command) => {
     );
   };
 
+  const handleCopyGoogleSheetsRange = async () => {
+    const rangeInfo = getGoogleSheetsRangeInfo();
+    if (!rangeInfo) {
+      showToast(t("copyGoogleSheetsRangeFailure"));
+      return;
+    }
+    const emojiName = await getEmojiName();
+    const sheetTitle = getFormattedTitle();
+    const linkText = sheetTitle;
+    const text = `${emojiName} ${linkText}`;
+    const html = `${emojiName}&nbsp;<a href="${rangeInfo.link}">${linkText}</a>&nbsp;`;
+    const fallbackElement = document.createElement("span");
+    fallbackElement.appendChild(document.createTextNode(`${emojiName} `));
+    const anchor = document.createElement("a");
+    anchor.setAttribute("href", rangeInfo.link);
+    anchor.textContent = linkText;
+    fallbackElement.appendChild(anchor);
+    await copyToClipboard(
+      text,
+      t("copyGoogleSheetsRangeSuccess"),
+      t("copyGoogleSheetsRangeFailure"),
+      html,
+      fallbackElement
+    );
+  };
+
   const commandMap: Record<Command, () => Promise<void>> = {
     "copy-title": handleCopyTitle,
     "copy-link": handleCopyLink,
     "copy-link-for-slack": handleCopyLinkForSlack,
+    "copy-google-sheets-range": handleCopyGoogleSheetsRange,
   };
 
   if (commandMap[command]) {

--- a/src/scripts/getGoogleSheetsRangeLink.ts
+++ b/src/scripts/getGoogleSheetsRangeLink.ts
@@ -1,0 +1,36 @@
+/**
+ * Gets Google Sheets range information (range string and link).
+ * This function extracts the current sheet ID (gid) and the selected range from Google Sheets.
+ *
+ * @returns {{ rangeString: string; link: string } | null} Range information with link, or null if the range cannot be determined.
+ */
+export const getGoogleSheetsRangeInfo = (): {
+  rangeString: string;
+  link: string;
+} | null => {
+  // 1. Get the current sheet ID (gid) from the URL
+  const currentUrl = window.location.href;
+  const urlObj = new URL(currentUrl);
+  const hashParams = new URLSearchParams(urlObj.hash.replace(/^#/, ""));
+  const gid = hashParams.get("gid") || "0";
+
+  // 2. Get the range string (e.g., A1 or A1:B5) from the name box
+  const nameBox = document.getElementById("t-name-box") as HTMLInputElement | null;
+  let rangeString = "";
+
+  if (nameBox && nameBox.value) {
+    rangeString = nameBox.value;
+  } else {
+    // Fallback when unable to get the range (or when focus is lost)
+    console.warn("Name box not found.");
+    return null;
+  }
+
+  // 3. Generate the link
+  // Get the base URL (up to the #)
+  const baseUrl = currentUrl.split("#")[0];
+  const finalLink = `${baseUrl}#gid=${gid}&range=${rangeString}`;
+
+  return { rangeString, link: finalLink };
+};
+

--- a/src/types/constants.ts
+++ b/src/types/constants.ts
@@ -9,6 +9,7 @@ export const VALID_COMMANDS = {
   COPY_LINK: "copy-link",
   COPY_LINK_FOR_SLACK: "copy-link-for-slack",
   COPY_TITLE: "copy-title",
+  COPY_GOOGLE_SHEETS_RANGE: "copy-google-sheets-range",
 } as const;
 
 export const EMOJI_KEYS = [


### PR DESCRIPTION
Hi wintorse,

Thank you for creating this great product! I use it regularly and really appreciate your work.

While using the extension, I found that I needed a feature to copy Google Sheets range links, so I implemented it and created this PR.

I'd be happy if you could take a look and decide whether this feature would be useful for your product. Even if you decide not to merge it, I'm grateful for your time reviewing it.

## Summary

This PR adds functionality to copy links for selected ranges in Google Sheets. Similar to the existing Slack emoji-enhanced link copy feature, users can now copy links that include the selected cell range (e.g., A1:B5).

## Changes

- Added `getGoogleSheetsRangeInfo()` function to extract the current sheet ID (gid) and selected range from Google Sheets
- Added `copy-google-sheets-range` command to copy range links with Slack emoji
- Added multilingual messages (English, Japanese, Chinese)
- Added new keyboard shortcut command to `manifest.json`

## Behavior

- When a cell range is selected in Google Sheets, execute the shortcut key
- Generates a link containing the selected range (e.g., `A1:B5`) and copies it along with Slack emoji and title
- Displays an error message when no range is selected

## Technical Details

- Extracts `gid` (sheet ID) from URL hash parameters
- Retrieves the selected range string from the DOM `t-name-box` element
- Range link format: `{baseUrl}#gid={gid}&range={rangeString}`

## Testing

- [x] Verified that links can be copied when a range is selected in Google Sheets
- [x] Verified that copied links point to the correct range

## Capture

https://github.com/user-attachments/assets/979be710-ee54-45ef-b1db-9fff80f90e3d

