### PR TITLE
🏗️ Create shared core helpers and wrap Chrome adapters

### DIFF
--- a/src/scripts/copyTextLink.ts
+++ b/src/scripts/copyTextLink.ts
@@ -2,157 +2,58 @@ import { getFormattedTitle } from "./getFormattedTitle";
 import { getEmojiName } from "./getEmojiName";
 import { getGoogleSheetsRangeInfo } from "./getGoogleSheetsRangeLink";
 import { showToast } from "../utils/toast";
+import { copyToClipboardShared } from "../shared/clipboard/copyToClipboardShared";
+import {
+  copyTextLinkCore,
+  type FallbackSpec,
+} from "../shared/clipboard/copyTextLinkCore";
 import type { Command } from "../types/types";
 
-/**
- * Copies text or a link to the clipboard based on the provided argument.
- *
- * @param {Command} command - The action to perform. Can be one of the following:
- *   - "copy-title": Copies the formatted title to the clipboard.
- *   - "copy-link": Copies a text link to the clipboard.
- *   - "copy-link-for-slack": Copies a text link with a Slack emoji name to the clipboard.
- *
- * The function also displays a toast message indicating the success or failure of the copy operation.
- */
-const copyToClipboard = async (
-  text: string,
-  successMessage: string,
-  failureMessage: string,
-  html?: string,
-  fallbackElement?: HTMLElement
-) => {
-  const notify = (message: string) => {
-    showToast(message);
-    // chrome.runtime.sendMessage({ type: "copylink.dev-notification", message });
-  };
-  try {
-    if (navigator.clipboard) {
-      if (html) {
-        await navigator.clipboard.write([
-          new ClipboardItem({
-            "text/plain": new Blob([text], { type: "text/plain" }),
-            "text/html": new Blob([html], { type: "text/html" }),
-          }),
-        ]);
-      } else {
-        await navigator.clipboard.writeText(text);
-      }
-      notify(successMessage);
-    } else {
-      throw new Error("Clipboard API not supported");
-    }
-  } catch (err) {
-    // notify(failureMessage);
-
-    // Fallback for HTTP URLs
-    // Clipboard API does not support HTTP URLs.
-    if (!fallbackElement) {
-      notify(failureMessage);
-      return;
-    }
-    document.body.appendChild(fallbackElement);
-    const range = document.createRange();
-    range.selectNode(fallbackElement);
-    const selection = window.getSelection();
-    if (selection) {
-      selection.removeAllRanges();
-      selection.addRange(range);
-      document.execCommand("copy");
-      selection.removeAllRanges();
-    }
-    document.body.removeChild(fallbackElement);
-    notify(successMessage);
+const createFallbackElement = (spec: FallbackSpec): HTMLElement | undefined => {
+  if (spec.type === "title") {
+    const el = document.createElement("p");
+    el.textContent = spec.title;
+    return el;
   }
+  if (spec.type === "link") {
+    const el = document.createElement("span");
+    const anchor = document.createElement("a");
+    anchor.setAttribute("href", spec.url);
+    anchor.textContent = spec.title;
+    el.appendChild(anchor);
+    el.appendChild(document.createTextNode("\u00A0"));
+    return el;
+  }
+  if (spec.type === "linkWithEmoji") {
+    const el = document.createElement("span");
+    el.appendChild(document.createTextNode(`${spec.emojiName} `));
+    const anchor = document.createElement("a");
+    anchor.setAttribute("href", spec.url);
+    anchor.textContent = spec.title;
+    el.appendChild(anchor);
+    return el;
+  }
+  if (spec.type === "sheetsRange") {
+    const el = document.createElement("span");
+    el.appendChild(document.createTextNode(`${spec.emojiName} `));
+    const anchor = document.createElement("a");
+    anchor.setAttribute("href", spec.link);
+    anchor.textContent = spec.text;
+    el.appendChild(anchor);
+    return el;
+  }
+  return undefined;
 };
 
-/**
- * Copies text or a link to the clipboard based on the provided argument.
- *
- * @param {Command} command - The action to perform.
- *
- * The function also displays a toast message indicating the success or failure of the copy operation.
- */
 export const copyTextLink = async (command: Command) => {
-  const title = getFormattedTitle();
-  const url = document.URL;
-  const t = (key: string): string => chrome.i18n.getMessage(key);
-
-  const handleCopyTitle = async () => {
-    const fallbackElement = document.createElement("p");
-    fallbackElement.textContent = title;
-    await copyToClipboard(
-      title,
-      t("copyTitleSuccess"),
-      t("copyTitleFailure"),
-      undefined,
-      fallbackElement
-    );
-  };
-
-  const handleCopyLink = async () => {
-    const html = `<a href="${url}">${title}</a>&nbsp;`;
-    const fallbackElement = document.createElement("span");
-    const anchor = document.createElement("a");
-    anchor.setAttribute("href", url);
-    anchor.textContent = title;
-    fallbackElement.appendChild(anchor);
-    fallbackElement.appendChild(document.createTextNode("\u00A0"));
-    await copyToClipboard(
-      title,
-      t("copyLinkSuccess"),
-      t("copyLinkFailure"),
-      html,
-      fallbackElement
-    );
-  };
-
-  const handleCopyLinkForSlack = async () => {
-    const emojiName = await getEmojiName();
-    const html = `${emojiName}&nbsp;<a href="${url}">${title}</a>&nbsp;`;
-    const fallbackElement = document.createElement("span");
-    fallbackElement.appendChild(document.createTextNode(`${emojiName} `));
-    const anchor = document.createElement("a");
-    anchor.setAttribute("href", url);
-    anchor.textContent = title;
-    fallbackElement.appendChild(anchor);
-    await copyToClipboard(
-      title,
-      t("copyLinkSuccess"),
-      t("copyLinkFailure"),
-      html,
-      fallbackElement
-    );
-  };
-
-  const handleCopyGoogleSheetsRange = async () => {
-    const rangeInfo = getGoogleSheetsRangeInfo();
-    if (!rangeInfo) {
-      showToast(t("copyGoogleSheetsRangeFailure"));
-      return;
-    }
-    const emojiName = await getEmojiName();
-    const sheetTitle = getFormattedTitle();
-    const linkText = sheetTitle;
-    const text = `${emojiName} ${linkText}`;
-    const html = `${emojiName}&nbsp;<a href="${rangeInfo.link}">${linkText}</a>&nbsp;`;
-    await copyToClipboard(
-      text,
-      t("copyGoogleSheetsRangeSuccess"),
-      t("copyGoogleSheetsRangeFailure"),
-      html,
-    );
-  };
-
-  const commandMap: Record<Command, () => Promise<void>> = {
-    "copy-title": handleCopyTitle,
-    "copy-link": handleCopyLink,
-    "copy-link-for-slack": handleCopyLinkForSlack,
-    "copy-google-sheets-range": handleCopyGoogleSheetsRange,
-  };
-
-  if (commandMap[command]) {
-    await commandMap[command]();
-  } else {
-    showToast("Unknown command");
-  }
+  await copyTextLinkCore(command, {
+    t: (key: string) => chrome.i18n.getMessage(key),
+    getEmojiName,
+    getFormattedTitle,
+    getGoogleSheetsRangeInfo,
+    getUrl: () => document.URL,
+    notify: showToast,
+    copy: copyToClipboardShared,
+    createFallbackElement,
+  });
 };

--- a/src/scripts/getEmojiName.ts
+++ b/src/scripts/getEmojiName.ts
@@ -1,119 +1,44 @@
 import type { CustomRegexes, EmojiNameRecord } from "../types/types";
+import { DEFAULT_EMOJI_NAMES } from "../types/constants";
 import {
-  DEFAULT_EMOJI_NAMES,
-  CUSTOM_EMOJI_KEYS,
-  CUSTOM_REGEX_KEYS,
-} from "../types/constants";
+  resolveEmojiName,
+  type PageContext,
+} from "../shared/emojiResolver";
 
 type StorageData = {
   emojiNames?: Partial<EmojiNameRecord>;
   copylinkdevCustomRegexes?: Partial<CustomRegexes>;
 };
 
+const buildPageContext = (): PageContext => ({
+  href: window.location.href,
+  hostname: window.location.hostname,
+  pathname: window.location.pathname,
+  documentBodyId: document.body.id,
+  documentTitle: document.title,
+  hasRedmineFooter: !!document
+    .querySelector("#footer a")
+    ?.textContent?.includes("Redmine"),
+  hasRedocWrap: !!document.querySelector(".redoc-wrap"),
+});
+
 /**
- * Retrieves the appropriate emoji name based on the current URL's hostname and pathname, or the document contents.
- * The emoji names are stored in the browser's local storage.
- *
- * @returns {Promise<string>} A promise that resolves to the corresponding emoji name.
+ * Retrieves the appropriate emoji name based on the current URL or document snapshot.
+ * Platform dependencies (storage, DOM, i18n) are handled in this wrapper; the
+ * core resolution logic lives in `shared/emojiResolver`.
  */
 export const getEmojiName = (): Promise<string> =>
   new Promise((resolve) => {
     chrome.storage.local.get(
       ["emojiNames", "copylinkdevCustomRegexes"],
       (data: StorageData) => {
-        const emojiNames: Partial<EmojiNameRecord> = data.emojiNames || {};
-        const customRegexes: Partial<CustomRegexes> =
-          data.copylinkdevCustomRegexes || {};
-        const getEmoji = (key: keyof EmojiNameRecord) =>
-          emojiNames[key] ?? DEFAULT_EMOJI_NAMES[key];
-        const href = window.location.href;
-        const hostname = window.location.hostname;
-        const pathname = window.location.pathname;
-        const pathParts = pathname.split("/");
-
-        for (const [index, regexKey] of CUSTOM_REGEX_KEYS.entries()) {
-          const websiteKey = CUSTOM_EMOJI_KEYS[index];
-          const regexPattern = customRegexes[regexKey];
-
-          if (
-            emojiNames[websiteKey] &&
-            regexPattern &&
-            new RegExp(regexPattern).test(href)
-          ) {
-            resolve(getEmoji(websiteKey));
-            return;
-          }
-        }
-
-        // the extension's main use case (e.g. Google Workspaces and GitHub) should
-        // resolve without doing any heavier DOM queries.
-        if (hostname === "docs.google.com") {
-          switch (pathParts[1]) {
-            case "spreadsheets":
-              resolve(getEmoji("googleSheets"));
-              return;
-            case "document":
-              resolve(getEmoji("googleDocs"));
-              return;
-            case "presentation":
-              resolve(getEmoji("googleSlides"));
-              return;
-            default:
-              resolve(getEmoji("googleDrive"));
-              return;
-          }
-        }
-
-        if (hostname === "drive.google.com") {
-          resolve(getEmoji("googleDrive"));
-          return;
-        }
-
-        if (hostname === "github.com") {
-          switch (pathParts[3]) {
-            case "pull":
-              resolve(getEmoji("githubPullRequest"));
-              return;
-            case "issues":
-              resolve(getEmoji("githubIssue"));
-              return;
-            default:
-              resolve(getEmoji("github"));
-              return;
-          }
-        }
-
-        if (hostname === "app.asana.com") {
-          resolve(getEmoji("asanaTask"));
-          return;
-        }
-
-        if (hostname.includes("backlog")) {
-          resolve(getEmoji("backlogIssue"));
-          return;
-        }
-
-        if (
-          hostname.includes("redmine") ||
-          document.querySelector("#footer a")?.textContent?.includes("Redmine")
-        ) {
-          resolve(getEmoji("redmineIssue"));
-          return;
-        }
-
-        if (document.body.id === "jira") {
-          resolve(getEmoji("jiraIssue"));
-          return;
-        }
-
-        if (
-          document.title.includes("ReDoc") ||
-          document.querySelector(".redoc-wrap")
-        ) {
-          resolve(getEmoji("reDoc"));
-          return;
-        }
-        resolve("");
-      }
+        const ctx = buildPageContext();
+        const name = resolveEmojiName(ctx, {
+          emojiNames: data.emojiNames,
+          customRegexes: data.copylinkdevCustomRegexes,
+          defaults: DEFAULT_EMOJI_NAMES,
+        });
+        resolve(name);
+      },
     );
   });

--- a/src/shared/clipboard/copyTextLinkCore.ts
+++ b/src/shared/clipboard/copyTextLinkCore.ts
@@ -1,0 +1,116 @@
+import type { Command } from "../../types/types";
+import type { CopyResult } from "./copyToClipboardShared";
+
+export type FallbackSpec =
+  | { type: "title"; title: string }
+  | { type: "link"; title: string; url: string }
+  | { type: "linkWithEmoji"; title: string; url: string; emojiName: string }
+  | { type: "sheetsRange"; text: string; link: string; emojiName: string };
+
+export type CopyTextLinkDeps = {
+  t: (key: string) => string;
+  getEmojiName: () => Promise<string>;
+  getFormattedTitle: () => string;
+  getGoogleSheetsRangeInfo: () => { link: string } | null;
+  getUrl: () => string;
+  notify: (message: string) => void;
+  copy: (
+    text: string,
+    html?: string,
+    fallbackElement?: HTMLElement,
+  ) => Promise<CopyResult>;
+  createFallbackElement: (spec: FallbackSpec) => HTMLElement | undefined;
+};
+
+export const copyTextLinkCore = async (
+  command: Command,
+  deps: CopyTextLinkDeps,
+): Promise<void> => {
+  const {
+    t,
+    getEmojiName,
+    getFormattedTitle,
+    getGoogleSheetsRangeInfo,
+    getUrl,
+  } = deps;
+  const title = getFormattedTitle();
+  const url = getUrl();
+
+  const notifySuccess = (messageKey: string) => deps.notify(t(messageKey));
+  const notifyFailure = (messageKey: string) => deps.notify(t(messageKey));
+
+  const runCopy = async (
+    text: string,
+    html: string | undefined,
+    fallbackSpec: FallbackSpec | undefined,
+    successKey: string,
+    failureKey: string,
+  ) => {
+    const fallbackElement = fallbackSpec
+      ? deps.createFallbackElement(fallbackSpec)
+      : undefined;
+    const result = await deps.copy(text, html, fallbackElement);
+    if (result.success) {
+      notifySuccess(successKey);
+    } else {
+      notifyFailure(failureKey);
+    }
+  };
+
+  if (command === "copy-title") {
+    await runCopy(
+      title,
+      undefined,
+      { type: "title", title },
+      "copyTitleSuccess",
+      "copyTitleFailure",
+    );
+    return;
+  }
+
+  if (command === "copy-link") {
+    const html = `<a href="${url}">${title}</a>&nbsp;`;
+    await runCopy(
+      title,
+      html,
+      { type: "link", title, url },
+      "copyLinkSuccess",
+      "copyLinkFailure",
+    );
+    return;
+  }
+
+  if (command === "copy-link-for-slack") {
+    const emojiName = await getEmojiName();
+    const html = `${emojiName}&nbsp;<a href="${url}">${title}</a>&nbsp;`;
+    await runCopy(
+      title,
+      html,
+      { type: "linkWithEmoji", title, url, emojiName },
+      "copyLinkSuccess",
+      "copyLinkFailure",
+    );
+    return;
+  }
+
+  if (command === "copy-google-sheets-range") {
+    const rangeInfo = getGoogleSheetsRangeInfo();
+    if (!rangeInfo) {
+      deps.notify(t("copyGoogleSheetsRangeFailure"));
+      return;
+    }
+    const emojiName = await getEmojiName();
+    const text = `${emojiName} ${title}`;
+    const html = `${emojiName}&nbsp;<a href="${rangeInfo.link}">${title}</a>&nbsp;`;
+    await runCopy(
+      text,
+      html,
+      { type: "sheetsRange", text, link: rangeInfo.link, emojiName },
+      "copyGoogleSheetsRangeSuccess",
+      "copyGoogleSheetsRangeFailure",
+    );
+    return;
+  }
+
+  deps.notify("Unknown command");
+};

--- a/src/shared/clipboard/copyToClipboardShared.ts
+++ b/src/shared/clipboard/copyToClipboardShared.ts
@@ -1,0 +1,56 @@
+export type CopyResult = { success: boolean; error?: unknown };
+
+/**
+ * Platform-neutral clipboard helper with optional HTML and fallback element.
+ * - Tries `navigator.clipboard` first.
+ * - Falls back to `execCommand('copy')` on the provided `fallbackElement` when available.
+ * - Returns a boolean result and keeps UI concerns (toast/i18n) at the call site.
+ */
+export const copyToClipboardShared = async (
+  text: string,
+  html?: string,
+  fallbackElement?: HTMLElement,
+): Promise<CopyResult> => {
+  try {
+    if (navigator.clipboard) {
+      if (html && "ClipboardItem" in window) {
+        const ClipboardItemCtor = (
+          window as typeof window & {
+            ClipboardItem: typeof ClipboardItem;
+          }
+        ).ClipboardItem;
+        await navigator.clipboard.write([
+          new ClipboardItemCtor({
+            "text/plain": new Blob([text], { type: "text/plain" }),
+            "text/html": new Blob([html], { type: "text/html" }),
+          }),
+        ]);
+      } else {
+        await navigator.clipboard.writeText(text);
+      }
+      return { success: true };
+    }
+    throw new Error("Clipboard API not available");
+  } catch (error) {
+    if (!fallbackElement) {
+      return { success: false, error };
+    }
+    document.body.appendChild(fallbackElement);
+    const range = document.createRange();
+    range.selectNode(fallbackElement);
+    const selection = window.getSelection();
+    let success = false;
+    if (selection) {
+      selection.removeAllRanges();
+      selection.addRange(range);
+      try {
+        success = document.execCommand("copy");
+      } catch (err) {
+        success = false;
+      }
+      selection.removeAllRanges();
+    }
+    document.body.removeChild(fallbackElement);
+    return { success, error };
+  }
+};

--- a/src/shared/emojiResolver.ts
+++ b/src/shared/emojiResolver.ts
@@ -1,0 +1,101 @@
+import type { CustomRegexes, EmojiNameRecord } from "../types/types";
+import {
+  CUSTOM_EMOJI_KEYS,
+  CUSTOM_REGEX_KEYS,
+  DEFAULT_EMOJI_NAMES,
+} from "../types/constants";
+
+export type PageContext = {
+  href: string;
+  hostname: string;
+  pathname: string;
+  documentBodyId?: string;
+  documentTitle?: string;
+  hasRedmineFooter?: boolean;
+  hasRedocWrap?: boolean;
+};
+
+export type EmojiResolverDeps = {
+  emojiNames?: Partial<EmojiNameRecord>;
+  customRegexes?: Partial<CustomRegexes>;
+  defaults?: EmojiNameRecord;
+};
+
+const getEmojiGetter =
+  (emojiNames: Partial<EmojiNameRecord>, defaults: EmojiNameRecord) =>
+  (key: keyof EmojiNameRecord) =>
+    emojiNames[key] ?? defaults[key];
+
+export const resolveEmojiName = (
+  ctx: PageContext,
+  deps: EmojiResolverDeps,
+): string => {
+  const emojiNames = deps.emojiNames ?? {};
+  const customRegexes = deps.customRegexes ?? {};
+  const defaults = deps.defaults ?? DEFAULT_EMOJI_NAMES;
+  const getEmoji = getEmojiGetter(emojiNames, defaults);
+
+  for (const [index, regexKey] of CUSTOM_REGEX_KEYS.entries()) {
+    const websiteKey = CUSTOM_EMOJI_KEYS[index];
+    const regexPattern = customRegexes[regexKey];
+    if (
+      emojiNames[websiteKey] &&
+      regexPattern &&
+      new RegExp(regexPattern).test(ctx.href)
+    ) {
+      return getEmoji(websiteKey);
+    }
+  }
+
+  const pathParts = ctx.pathname.split("/");
+
+  if (ctx.hostname === "docs.google.com") {
+    switch (pathParts[1]) {
+      case "spreadsheets":
+        return getEmoji("googleSheets");
+      case "document":
+        return getEmoji("googleDocs");
+      case "presentation":
+        return getEmoji("googleSlides");
+      default:
+        return getEmoji("googleDrive");
+    }
+  }
+
+  if (ctx.hostname === "drive.google.com") {
+    return getEmoji("googleDrive");
+  }
+
+  if (ctx.hostname === "github.com") {
+    switch (pathParts[3]) {
+      case "pull":
+        return getEmoji("githubPullRequest");
+      case "issues":
+        return getEmoji("githubIssue");
+      default:
+        return getEmoji("github");
+    }
+  }
+
+  if (ctx.hostname === "app.asana.com") {
+    return getEmoji("asanaTask");
+  }
+
+  if (ctx.hostname.includes("backlog")) {
+    return getEmoji("backlogIssue");
+  }
+
+  if (ctx.hostname.includes("redmine") || ctx.hasRedmineFooter) {
+    return getEmoji("redmineIssue");
+  }
+
+  if (ctx.documentBodyId === "jira") {
+    return getEmoji("jiraIssue");
+  }
+
+  if (ctx.documentTitle?.includes("ReDoc") || ctx.hasRedocWrap) {
+    return getEmoji("reDoc");
+  }
+
+  return "";
+};

--- a/src/shared/popup/emojiSettings.ts
+++ b/src/shared/popup/emojiSettings.ts
@@ -1,0 +1,66 @@
+import type {
+  CustomRegexes,
+  CustomRegexKeys,
+  EmojiKeys,
+  EmojiName,
+  EmojiNameRecord,
+} from "../../types/types";
+import {
+  CUSTOM_REGEX_KEYS,
+  DEFAULT_EMOJI_NAMES,
+  EMOJI_KEYS,
+} from "../../types/constants";
+
+export const isEmojiFormat = (value: string): value is EmojiName =>
+  /^:.*:$/.test(value);
+
+export const normalizeEmojiValue = (
+  value: string,
+  defaultValue: EmojiName,
+): EmojiName => {
+  const trimmed = value.trim();
+  if (!trimmed) return defaultValue;
+  if (isEmojiFormat(trimmed)) return trimmed;
+  return `:${trimmed}:`;
+};
+
+export const buildEmojiNames = (
+  values: Partial<Record<EmojiKeys, string>>,
+  defaults: EmojiNameRecord = DEFAULT_EMOJI_NAMES,
+): Partial<EmojiNameRecord> => {
+  const result: Partial<EmojiNameRecord> = {};
+  for (const key of EMOJI_KEYS) {
+    const rawValue = values[key] ?? "";
+    result[key] = normalizeEmojiValue(rawValue, defaults[key]);
+  }
+  return result;
+};
+
+export const buildCustomRegexes = (
+  values: Partial<Record<CustomRegexKeys, string>>,
+): Partial<CustomRegexes> => {
+  const result: Partial<CustomRegexes> = {};
+  for (const key of CUSTOM_REGEX_KEYS) {
+    const rawValue = values[key];
+    if (typeof rawValue === "string") {
+      result[key] = rawValue;
+    }
+  }
+  return result;
+};
+
+export const getInitialEmojiValues = (
+  stored?: Partial<EmojiNameRecord>,
+  defaults: EmojiNameRecord = DEFAULT_EMOJI_NAMES,
+): EmojiNameRecord => {
+  const result = { ...defaults } as EmojiNameRecord;
+  if (stored) {
+    for (const key of EMOJI_KEYS) {
+      const value = stored[key];
+      if (value) {
+        result[key] = normalizeEmojiValue(value, defaults[key]);
+      }
+    }
+  }
+  return result;
+};

--- a/src/shared/ui/notification.ts
+++ b/src/shared/ui/notification.ts
@@ -1,0 +1,18 @@
+export type NotificationConfig = {
+  id: string;
+  title: string;
+  message: string;
+  iconPath: string;
+  autoClearMs?: number;
+};
+
+export const buildNotificationConfig = (
+  message: string,
+  options?: Partial<NotificationConfig>,
+): NotificationConfig => ({
+  id: options?.id ?? "copylink.dev-notification",
+  title: options?.title ?? "copylink.dev",
+  message,
+  iconPath: options?.iconPath ?? "images/icon-128.png",
+  autoClearMs: options?.autoClearMs ?? 3000,
+});

--- a/src/shared/ui/toast.ts
+++ b/src/shared/ui/toast.ts
@@ -1,0 +1,38 @@
+export type ToastDeps = {
+  document: Document;
+  getCssHref: () => string;
+};
+
+export const showToastCore = (message: string, deps: ToastDeps) => {
+  const { document, getCssHref } = deps;
+  const link = document.createElement("link");
+  link.rel = "stylesheet";
+  link.href = getCssHref();
+  document.head.appendChild(link);
+
+  link.onload = () => {
+    const toast = document.createElement("div");
+    toast.textContent = message;
+    toast.className = "copylink-dev-toast";
+
+    toast.style.opacity = "0";
+    toast.style.transform = "translate3d(0, 24px, 0)";
+
+    document.body.appendChild(toast);
+
+    toast.offsetHeight;
+
+    setTimeout(() => {
+      toast.style.transform = "translate3d(0, 0, 0)";
+      toast.style.opacity = "1";
+    }, 10);
+
+    setTimeout(() => {
+      toast.style.transform = "translate3d(0, 12px, 0)";
+      toast.style.opacity = "0";
+      setTimeout(() => {
+        toast.remove();
+      }, 310);
+    }, 3000);
+  };
+};

--- a/src/utils/notification.ts
+++ b/src/utils/notification.ts
@@ -1,35 +1,34 @@
+import { buildNotificationConfig } from "../shared/ui/notification";
+
 /**
- * Displays a notification.
- *
- * @param {string} message
+ * Chrome extension wrapper for notifications. Uses shared config builder and injects runtime URLs.
  */
 export const createNotification = (message: string) => {
-  const notificationId = "copylink.dev-notification";
+  const config = buildNotificationConfig(message);
   chrome.notifications.create(
-    notificationId,
+    config.id,
     {
       type: "basic",
-      iconUrl: chrome.runtime.getURL("images/icon-128.png"),
-      title: "copylink.dev",
-      message: message,
+      iconUrl: chrome.runtime.getURL(config.iconPath),
+      title: config.title,
+      message: config.message,
       silent: true,
     },
     () => {
       if (chrome.runtime.lastError) {
         console.error(chrome.runtime.lastError);
-      } else {
-        setTimeout(() => {
-          chrome.notifications.clear(notificationId, (wasCleared) => {
-            if (chrome.runtime.lastError) {
-              console.error(chrome.runtime.lastError);
-            } else if (!wasCleared) {
-              console.error(
-                `Failed to clear notification with ID: ${notificationId}`
-              );
-            }
-          });
-        }, 3000);
+        return;
       }
-    }
+      if (!config.autoClearMs) return;
+      setTimeout(() => {
+        chrome.notifications.clear(config.id, (wasCleared) => {
+          if (chrome.runtime.lastError) {
+            console.error(chrome.runtime.lastError);
+          } else if (!wasCleared) {
+            console.error(`Failed to clear notification with ID: ${config.id}`);
+          }
+        });
+      }, config.autoClearMs);
+    },
   );
 };

--- a/src/utils/toast.ts
+++ b/src/utils/toast.ts
@@ -1,43 +1,10 @@
+import { showToastCore } from "../shared/ui/toast";
+
 /**
- * Displays a toast message on the bottom left of the screen.
- *
- * @param {string} message
+ * Chrome extension wrapper for toast rendering. Provides platform-specific URL resolver.
  */
-export const showToast = (message: string) => {
-  // load CSS file for toast
-  const link = document.createElement("link");
-  link.rel = "stylesheet";
-  link.href = chrome.runtime.getURL("../styles/toast.css");
-  document.head.appendChild(link);
-
-  // Wait for the CSS to load
-  link.onload = () => {
-    const toast = document.createElement("div");
-    toast.textContent = message;
-    toast.className = "copylink-dev-toast";
-
-    // Set initial styles
-    toast.style.opacity = "0";
-    toast.style.transform = "translate3d(0, 24px, 0)";
-
-    document.body.appendChild(toast);
-
-    // Force reflow
-    toast.offsetHeight;
-
-    // slide in and fade in
-    setTimeout(() => {
-      toast.style.transform = "translate3d(0, 0, 0)";
-      toast.style.opacity = "1";
-    }, 10);
-
-    // slide out and fade out
-    setTimeout(() => {
-      toast.style.transform = "translate3d(0, 12px, 0)";
-      toast.style.opacity = "0";
-      setTimeout(() => {
-        toast.remove();
-      }, 310);
-    }, 3000);
-  };
-};
+export const showToast = (message: string) =>
+  showToastCore(message, {
+    document,
+    getCssHref: () => chrome.runtime.getURL("../styles/toast.css"),
+  });


### PR DESCRIPTION
## Summary
- extract emoji resolution, clipboard copying, toast/notification config, and popup normalization into src/shared so core logic no longer depends on chrome APIs
- keep existing scripts/popup/utils files as adapters that assemble dependencies (messages, storage, DOM nodes, runtime URLs) before calling shared cores
- reuse the new shared clipboard helper across copyTextLink and any future environments