### PR TITLE
✨ Refactor toast rendering

### DIFF
--- a/src/shared/ui/toast.ts
+++ b/src/shared/ui/toast.ts
@@ -1,38 +1,81 @@
-export type ToastDeps = {
-  document: Document;
-  getCssHref: () => string;
+export type ToastOptions = {
+  durationMs?: number;
+  /**
+   * Customize the toast content. The provided element has the base styling applied.
+   * This allows consumers (e.g., userscript) to add buttons/links next to the message.
+   */
+  renderContent?: (container: HTMLElement, message: string) => void;
 };
 
-export const showToastCore = (message: string, deps: ToastDeps) => {
-  const { document, getCssHref } = deps;
-  const link = document.createElement("link");
-  link.rel = "stylesheet";
-  link.href = getCssHref();
-  document.head.appendChild(link);
+const CLASSES = {
+  wrapper: "copylink-dev-toast-wrapper",
+  visible: "visible",
+  message: "copylink-dev-toast",
+};
 
-  link.onload = () => {
-    const toast = document.createElement("div");
+const toastStyle = `
+  :host {
+    all: initial;
+  }
+  .${CLASSES.wrapper} {
+    position: fixed;
+    bottom: 24px;
+    left: 24px;
+    z-index: 2147483647;
+    pointer-events: none;
+    display: flex;
+    align-items: center;
+  }
+  .${CLASSES.message} {
+    font-family: inherit;
+    background: rgba(0, 0, 0, 0.8);
+    color: white;
+    border-radius: 8px;
+    padding: 10px 16px;
+    opacity: 0;
+    transform: translate3d(0, 24px, 0);
+    transition: transform 0.3s ease, opacity 0.3s ease;
+    display: inline-flex;
+    gap: 8px;
+    align-items: center;
+  }
+  .${CLASSES.wrapper}.${CLASSES.visible} .${CLASSES.message} {
+    opacity: 1;
+    transform: translate3d(0, 0, 0);
+  }
+`;
+
+export const showToastCore = (
+  message: string,
+  document: Document,
+  options?: ToastOptions,
+) => {
+  const wrapper = document.createElement("div");
+  wrapper.className = CLASSES.wrapper;
+  const shadow = wrapper.attachShadow({ mode: "open" });
+  const style = document.createElement("style");
+  style.textContent = toastStyle;
+  const toast = document.createElement("div");
+  toast.className = CLASSES.message;
+  if (options?.renderContent) {
+    options.renderContent(toast, message);
+  } else {
     toast.textContent = message;
-    toast.className = "copylink-dev-toast";
+  }
+  shadow.appendChild(style);
+  shadow.appendChild(toast);
+  document.body.appendChild(wrapper);
 
-    toast.style.opacity = "0";
-    toast.style.transform = "translate3d(0, 24px, 0)";
+  requestAnimationFrame(() => {
+    wrapper.classList.add(CLASSES.visible);
+  });
 
-    document.body.appendChild(toast);
-
-    toast.offsetHeight;
-
+  const duration = options?.durationMs ?? 3000;
+  setTimeout(() => {
+    wrapper.classList.remove(CLASSES.visible);
     setTimeout(() => {
-      toast.style.transform = "translate3d(0, 0, 0)";
-      toast.style.opacity = "1";
-    }, 10);
-
-    setTimeout(() => {
-      toast.style.transform = "translate3d(0, 12px, 0)";
-      toast.style.opacity = "0";
-      setTimeout(() => {
-        toast.remove();
-      }, 310);
-    }, 3000);
-  };
+      style.remove();
+      wrapper.remove();
+    }, 200);
+  }, duration);
 };

--- a/src/utils/toast.ts
+++ b/src/utils/toast.ts
@@ -1,10 +1,6 @@
 import { showToastCore } from "../shared/ui/toast";
 
 /**
- * Chrome extension wrapper for toast rendering. Provides platform-specific URL resolver.
+ * Chrome extension wrapper for toast rendering. No additional CSS needed because the shared core handles styling.
  */
-export const showToast = (message: string) =>
-  showToastCore(message, {
-    document,
-    getCssHref: () => chrome.runtime.getURL("../styles/toast.css"),
-  });
+export const showToast = (message: string) => showToastCore(message, document);


### PR DESCRIPTION
# Summary
- Refactored toast core to render in a shadow host with inline styles/animation, supporting customizable content via `renderContent(container, message)` and duration control.
- Updated Chrome adapter to delegate directly to the shared core with `document` and rely on the core styling/animation.