### PR TITLE
✨ Support Markdown link format for Google Sheets range copy

### DIFF
--- a/src/shared/clipboard/copyTextLinkCore.ts
+++ b/src/shared/clipboard/copyTextLinkCore.ts
@@ -149,7 +149,7 @@ export const copyTextLinkCore = async (
     const emojiName = await getEmojiName();
     const html = `${emojiName}&nbsp;<a href="${rangeInfo.link}">${title}</a>&nbsp;`;
     await runCopy(
-      title,
+      `[${title}](${rangeInfo.link})`,
       html,
       { type: "sheetsRange", title, link: rangeInfo.link, emojiName },
       "copyGoogleSheetsRangeSuccess",


### PR DESCRIPTION
## Summary
This PR addresses a missed change from #25.

Specifically, it updates the plain-text payload for `copy-google-sheets-range` to use Markdown link format (`[title](url)`), so behavior is consistent with the Markdown plain-text handling introduced in #25.

## Why
A required change was left out when #25 was merged. This PR completes that missing part.