### PR TITLE
fix: improve HTTP clipboard fallback for plain/html copy

### DIFF
--- a/src/shared/clipboard/copyToClipboardShared.ts
+++ b/src/shared/clipboard/copyToClipboardShared.ts
@@ -3,7 +3,8 @@ export type CopyResult = { success: boolean; error?: unknown };
 /**
  * Platform-neutral clipboard helper with optional HTML and fallback element.
  * - Tries `navigator.clipboard` first.
- * - Falls back to `execCommand('copy')` on the provided `fallbackElement` when available.
+ * - Falls back to `execCommand('copy')` + `copy` event handling on the provided `fallbackElement` when available.
+ *   In fallback mode, sets `text/plain` and optionally `text/html` via `ClipboardEvent.clipboardData`.
  * - Returns a boolean result and keeps UI concerns (toast/i18n) at the call site.
  * @param text Plain-text content to copy.
  * @param html Optional HTML content to copy.
@@ -31,23 +32,60 @@ export const copyToClipboardShared = async (
     if (!fallbackElement) {
       return { success: false, error };
     }
-    document.body.appendChild(fallbackElement);
-    const range = document.createRange();
-    range.selectNode(fallbackElement);
     const selection = window.getSelection();
-    let success = false;
+    const previousRanges: Array<Range> = [];
     if (selection) {
-      selection.removeAllRanges();
-      selection.addRange(range);
-      try {
-        // oxlint-disable-next-line no-deprecated --- Required for legacy copy support
-        success = document.execCommand("copy");
-      } catch {
-        success = false;
+      for (let i = 0; i < selection.rangeCount; i += 1) {
+        previousRanges.push(selection.getRangeAt(i).cloneRange());
       }
-      selection.removeAllRanges();
     }
-    document.body.removeChild(fallbackElement);
+
+    let success = false;
+    let copiedViaClipboardData = false;
+    let listenerAttached = false;
+    const onCopy = (event: ClipboardEvent): void => {
+      const clipboardData = event.clipboardData;
+      if (!clipboardData) {
+        return;
+      }
+      event.preventDefault();
+      clipboardData.setData("text/plain", text);
+      if (typeof html === "string") {
+        clipboardData.setData("text/html", html);
+      }
+      copiedViaClipboardData = true;
+    };
+    try {
+      document.addEventListener("copy", onCopy);
+      listenerAttached = true;
+      document.body.appendChild(fallbackElement);
+      if (selection) {
+        const range = document.createRange();
+        range.selectNode(fallbackElement);
+        selection.removeAllRanges();
+        selection.addRange(range);
+        try {
+          // oxlint-disable-next-line no-deprecated --- Required for copy support in HTTP pages
+          const commandSuccess = document.execCommand("copy");
+          success = copiedViaClipboardData || commandSuccess;
+        } catch {
+          success = false;
+        }
+      }
+    } finally {
+      if (selection) {
+        selection.removeAllRanges();
+        for (const range of previousRanges) {
+          selection.addRange(range);
+        }
+      }
+      if (listenerAttached) {
+        document.removeEventListener("copy", onCopy);
+      }
+      if (fallbackElement.isConnected) {
+        document.body.removeChild(fallbackElement);
+      }
+    }
     return { success, error };
   }
 };


### PR DESCRIPTION
## Summary
- Improve clipboard fallback behavior for environments where `navigator.clipboard.write` is unavailable or blocked (e.g. HTTP pages).
- In the legacy `execCommand("copy")` path, set both `text/plain` and `text/html` via the `copy` event when possible.
- Refactor cleanup and selection handling for maintainability.

## Changes
- Update `copyToClipboardShared` fallback flow in `src/shared/clipboard/copyToClipboardShared.ts`.
- Add `copy` event handling to explicitly set clipboard MIME data in fallback mode.
- Use unified `finally` cleanup for listener and temporary DOM node removal.
- Preserve and restore previous selection ranges.
- Update JSDoc to clarify fallback behavior.

## Why
- `ClipboardItem` is preferred but not always available/reliable depending on context.
- Explicit MIME assignment in fallback improves interoperability while preserving current UX.

## Verification
- tested on Chrome

## Scope
- Internal clipboard behavior only.
- No UI changes.
