### PR TITLE
✨ Add GitHub PR status support

### DIFF
--- a/docs/behavior-test-coverage-ja.md
+++ b/docs/behavior-test-coverage-ja.md
@@ -42,7 +42,16 @@
 | B-SITE-12 | ReDoc (Swagger)      | `:swagger:`           | アクティブラベルの2番目の span から取得            |
 | B-SITE-13 | 未登録サイト         | （なし）              | `document.title` をそのまま使用                    |
 
-### 1.4 カスタムWebサイト設定
+### 1.4 GitHub Pull Request 状態別絵文字
+
+| ID         | 機能                                                                                                    |
+| ---------- | ------------------------------------------------------------------------------------------------------- |
+| B-GH-PR-01 | Pull Requestページで Draft, Open, Merged, Closed ごとに別の絵文字を使用できる                           |
+| B-GH-PR-02 | Conversationページでは `data-status` (`draft`, `pullOpened`, `pullMerged` など) から状態を検出する      |
+| B-GH-PR-03 | Files Changedページでは `span[reviewable_state]` のテキスト (`Draft`, `Open` など) へフォールバックする |
+| B-GH-PR-04 | 状態別絵文字が未設定の場合、GitHub Pull Requestのデフォルト絵文字を使用する                             |
+
+### 1.5 カスタムWebサイト設定
 
 | ID          | 機能                                                                    |
 | ----------- | ----------------------------------------------------------------------- |
@@ -50,7 +59,7 @@
 | B-CUSTOM-02 | カスタム正規表現がビルトインサイト検出より優先される                    |
 | B-CUSTOM-03 | URLに対してカスタム正規表現がマッチした場合、対応する絵文字が適用される |
 
-### 1.5 ポップアップ設定
+### 1.6 ポップアップ設定
 
 | ID         | 機能                                                     |
 | ---------- | -------------------------------------------------------- |
@@ -59,7 +68,7 @@
 | B-POPUP-03 | Google Sheetsリンクフォーマットのラジオボタン選択（4種） |
 | B-POPUP-04 | 設定変更が `chrome.storage.local` にリアルタイム保存     |
 
-### 1.6 クリップボード動作
+### 1.7 クリップボード動作
 
 | ID        | 機能                                                                                   |
 | --------- | -------------------------------------------------------------------------------------- |
@@ -69,7 +78,7 @@
 | B-CLIP-04 | Copy Link: テキスト=タイトル、HTML=`<a>` タグ                                          |
 | B-CLIP-05 | Copy Link for Slack: テキスト=Markdown、HTML=絵文字+`<a>` タグ                         |
 
-### 1.7 Google Sheets 範囲リンク
+### 1.8 Google Sheets 範囲リンク
 
 | ID         | 機能                                                 |
 | ---------- | ---------------------------------------------------- |
@@ -79,7 +88,7 @@
 | B-RANGE-04 | 非Sheetsページでは何もしない                         |
 | B-RANGE-05 | フォーマット設定に応じた4種類の出力                  |
 
-### 1.8 トースト通知
+### 1.9 トースト通知
 
 | ID         | 機能                                                  |
 | ---------- | ----------------------------------------------------- |
@@ -88,7 +97,7 @@
 | B-TOAST-03 | 約3秒後に自動消去（フェードアウトアニメーション付き） |
 | B-TOAST-04 | Shadow DOMでページのスタイルから隔離                  |
 
-### 1.9 国際化 (i18n)
+### 1.10 国際化 (i18n)
 
 | ID        | 機能                                        |
 | --------- | ------------------------------------------- |
@@ -97,7 +106,7 @@
 | B-I18N-03 | 中国語簡体字 (zh_CN) サポート               |
 | B-I18N-04 | ポップアップの `[data-i18n]` による自動翻訳 |
 
-### 1.10 エラーハンドリング
+### 1.11 エラーハンドリング
 
 | ID       | 機能                                         |
 | -------- | -------------------------------------------- |
@@ -107,7 +116,7 @@
 | B-ERR-04 | Clipboard API失敗時のフォールバック          |
 | B-ERR-05 | 全コピー方法失敗時の失敗ステータス表示       |
 
-### 1.11 コンテントスクリプト
+### 1.12 コンテントスクリプト
 
 | ID      | 機能                                                          |
 | ------- | ------------------------------------------------------------- |
@@ -136,70 +145,75 @@
 
 ### カバレッジマッピング
 
-| 機能ID                   | 機能                                 | 状況 | テストファイル / テスト名                                                                                    |
-| ------------------------ | ------------------------------------ | ---- | ------------------------------------------------------------------------------------------------------------ |
-| **コアコマンド**         |                                      |      |                                                                                                              |
-| B-CMD-01                 | Copy Link                            | ✅   | `e2e/core-commands.spec.ts`: `copy-link copies title as text and HTML anchor`                                |
-| B-CMD-02                 | Copy Link for Slack                  | ✅   | `e2e/core-commands.spec.ts`: `copy-link-for-slack copies markdown text and HTML with emoji`                  |
-| B-CMD-03                 | Copy Title                           | ✅   | `e2e/core-commands.spec.ts`: `copy-title copies only the page title as plain text`                           |
-| B-CMD-04                 | Copy Google Sheets Range             | ✅   | `e2e/google-sheets.spec.ts`: `copy-google-sheets-range copies URL with range parameter`                      |
-| **リンクフォーマット**   |                                      |      |                                                                                                              |
-| B-FMT-01                 | Plain URL                            | ✅   | `e2e/link-formats.spec.ts`: `plainUrl format: text is URL only`                                              |
-| B-FMT-02                 | HTML                                 | ✅   | `e2e/link-formats.spec.ts`: `html format: text is title, html is <a> without emoji`                          |
-| B-FMT-03                 | Markdown                             | ✅   | `e2e/link-formats.spec.ts`: `markdown format: text is [title](url), no html`                                 |
-| B-FMT-04                 | HTML with Emoji                      | ✅   | `e2e/link-formats.spec.ts`: `htmlWithEmoji format: text is markdown, html has emoji + <a>`                   |
-| **サイト別処理**         |                                      |      |                                                                                                              |
-| B-SITE-01                | Google Docs                          | ✅   | `e2e/site-title.spec.ts`: `Google Docs: title is テスト document`                                            |
-| B-SITE-02                | Google Sheets                        | ✅   | `e2e/site-title.spec.ts`: `Google Sheets: title is テスト spreadsheet`                                       |
-| B-SITE-03                | Google Slides                        | ✅   | `e2e/site-title.spec.ts`: `Google Slides: title is テスト presentation`                                      |
-| B-SITE-04                | Google Drive                         | ✅   | `e2e/site-title.spec.ts`: `Google Drive: title is public folder`                                             |
-| B-SITE-05                | GitHub Repos                         | ✅   | `e2e/site-title.spec.ts`: `GitHub Repo: emoji is :github:`                                                   |
-| B-SITE-06                | GitHub Pull Requests                 | ✅   | `e2e/site-title.spec.ts`: `GitHub Pull Request: title is #<number> <text>`                                   |
-| B-SITE-07                | GitHub Issues                        | ✅   | `e2e/site-title.spec.ts`: `GitHub Issue: title is #<number> <text>`                                          |
-| B-SITE-08                | Jira Issues                          | ✅   | `e2e/site-title.spec.ts`: `Jira Issue: title is HIBERNATE-77 Support HQL in / not in`                        |
-| B-SITE-09                | Asana Tasks                          | ✅   | `e2e/site-title.spec.ts`: `Asana Task (mocked): title from aria-label`                                       |
-| B-SITE-10                | Backlog Issues                       | ✅   | `e2e/site-title.spec.ts`: `Backlog Issue (mocked): title from DOM selector`                                  |
-| B-SITE-11                | Redmine Issues                       | ✅   | `e2e/site-title.spec.ts`: `Redmine Issue: title is Feature #642: OpenXR On Linux.`                           |
-| B-SITE-12                | ReDoc (Swagger)                      | ✅   | `e2e/site-title.spec.ts`: `ReDoc: title is 法令本文取得API`                                                  |
-| B-SITE-13                | 未登録サイト                         | ✅   | `e2e/core-commands.spec.ts`: example.com で検証                                                              |
-| **カスタムWebサイト**    |                                      |      |                                                                                                              |
-| B-CUSTOM-01              | カスタムスロット設定                 | ✅   | `e2e/popup.spec.ts`: `custom website regex + emoji is applied for matching URLs`                             |
-| B-CUSTOM-02              | カスタムがビルトインより優先         | ✅   | `e2e/popup.spec.ts`: `custom website regex takes priority over built-in site detection`                      |
-| B-CUSTOM-03              | カスタム正規表現マッチ時の絵文字適用 | ✅   | `e2e/popup.spec.ts`: `custom website regex + emoji is applied for matching URLs`                             |
-| **ポップアップ設定**     |                                      |      |                                                                                                              |
-| B-POPUP-01               | 絵文字名の変更                       | ✅   | `e2e/popup.spec.ts`: `changing an emoji name persists and is used in copy`                                   |
-| B-POPUP-02               | カスタムWebサイト設定                | ✅   | `e2e/popup.spec.ts`: `custom website regex + emoji is applied for matching URLs`                             |
-| B-POPUP-03               | リンクフォーマット選択               | ✅   | `e2e/popup.spec.ts`: `selecting a link format radio persists to storage`                                     |
-| B-POPUP-04               | リアルタイムストレージ保存           | ✅   | `e2e/popup.spec.ts`: 各テストでストレージ確認                                                                |
-| **クリップボード**       |                                      |      |                                                                                                              |
-| B-CLIP-01                | Clipboard API デュアルフォーマット   | ✅   | `e2e/core-commands.spec.ts`: text + HTML の両方を検証                                                        |
-| B-CLIP-02                | HTTP フォールバック                  | ✅   | `e2e/http-site.spec.ts`: HTTP サイトでの3コマンドテスト                                                      |
-| B-CLIP-03                | 選択範囲の保持                       | ✅   | `unit/clipboardFallback.test.ts`: `restores the previous selection range after execCommand fallback`         |
-| B-CLIP-04                | Copy Link 出力フォーマット           | ✅   | `e2e/core-commands.spec.ts`                                                                                  |
-| B-CLIP-05                | Copy Link for Slack 出力フォーマット | ✅   | `e2e/core-commands.spec.ts`                                                                                  |
-| **Google Sheets 範囲**   |                                      |      |                                                                                                              |
-| B-RANGE-01               | GID 抽出                             | ✅   | `e2e/google-sheets.spec.ts`: `gid=0` の検証                                                                  |
-| B-RANGE-02               | セル範囲抽出                         | ✅   | `e2e/google-sheets.spec.ts`: `range=C2:E4` の検証                                                            |
-| B-RANGE-03               | リンク形式                           | ✅   | `e2e/google-sheets.spec.ts`                                                                                  |
-| B-RANGE-04               | 非Sheetsページでno-op                | ✅   | `e2e/google-sheets.spec.ts`: `on non-Sheets page does nothing`                                               |
-| B-RANGE-05               | フォーマット別出力                   | ✅   | `e2e/link-formats.spec.ts`: 4フォーマット全テスト                                                            |
-| **トースト通知**         |                                      |      |                                                                                                              |
-| B-TOAST-01               | コピー成功後に表示                   | ✅   | `e2e/toast.spec.ts`: `toast appears after copy-link`                                                         |
-| B-TOAST-02               | 表示位置                             | ✅   | `unit/toast-css.test.ts`: `positions the toast 24px from the bottom/left`                                    |
-| B-TOAST-03               | 約3秒後の自動消去                    | ✅   | `e2e/toast.spec.ts`: `disappears after ~3s`                                                                  |
-| B-TOAST-04               | Shadow DOM 隔離                      | ✅   | `unit/toastShadowDom.test.ts`: `places .copylink-dev-toast inside the shadow root, not in the main document` |
-| **国際化**               |                                      |      |                                                                                                              |
-| B-I18N-01                | 英語サポート                         | ✅   | `unit/i18n.test.ts`: `en/messages.json contains all required keys`                                           |
-| B-I18N-02                | 日本語サポート                       | ✅   | `unit/i18n.test.ts`: `ja/messages.json contains all required keys`                                           |
-| B-I18N-03                | 中国語サポート                       | ✅   | `unit/i18n.test.ts`: `zh_CN/messages.json contains all required keys`                                        |
-| B-I18N-04                | ポップアップ自動翻訳                 | ✅   | `unit/i18n.test.ts`: `every data-i18n attribute in popup.html references a key present in messages.json`     |
-| **エラーハンドリング**   |                                      |      |                                                                                                              |
-| B-ERR-01                 | タブ未発見時                         | ✅   | `unit/background.test.ts`: `logs an error and does nothing when no active tab is found`                      |
-| B-ERR-02                 | 非 http/https スキーム拒否           | ✅   | `unit/background.test.ts`: `rejects chrome:// URLs without injecting the content script`                     |
-| B-ERR-03                 | スクリプト注入失敗                   | ✅   | `unit/background.test.ts`: `logs error and does NOT send message when script injection fails`                |
-| B-ERR-04                 | Clipboard API 失敗フォールバック     | ✅   | `unit/clipboardFallback.test.ts`: `attempts the execCommand fallback when Clipboard API fails`               |
-| B-ERR-05                 | 全方法失敗時の失敗表示               | ✅   | `e2e/toast.spec.ts` + `unit/copyTextLinkCore.test.ts`: failure notification                                  |
-| **コンテントスクリプト** |                                      |      |                                                                                                              |
-| B-CS-01                  | 重複注入防止                         | ✅   | `unit/content.test.ts`: `does NOT re-register the listener when the script is injected a second time`        |
-| B-CS-02                  | Chrome 動的注入                      | ⚠️   | 全 E2E テストで暗黙的に動作を確認                                                                            |
-| B-CS-03                  | Firefox 事前注入                     | ❌   | Playwright は Firefox 拡張のテストをサポートしていないため未対応                                             |
+| 機能ID                     | 機能                                     | 状況 | テストファイル / テスト名                                                                                     |
+| -------------------------- | ---------------------------------------- | ---- | ------------------------------------------------------------------------------------------------------------- |
+| **コアコマンド**           |                                          |      |                                                                                                               |
+| B-CMD-01                   | Copy Link                                | ✅   | `e2e/core-commands.spec.ts`: `copy-link copies title as text and HTML anchor`                                 |
+| B-CMD-02                   | Copy Link for Slack                      | ✅   | `e2e/core-commands.spec.ts`: `copy-link-for-slack copies markdown text and HTML with emoji`                   |
+| B-CMD-03                   | Copy Title                               | ✅   | `e2e/core-commands.spec.ts`: `copy-title copies only the page title as plain text`                            |
+| B-CMD-04                   | Copy Google Sheets Range                 | ✅   | `e2e/google-sheets.spec.ts`: `copy-google-sheets-range copies URL with range parameter`                       |
+| **リンクフォーマット**     |                                          |      |                                                                                                               |
+| B-FMT-01                   | Plain URL                                | ✅   | `e2e/link-formats.spec.ts`: `plainUrl format: text is URL only`                                               |
+| B-FMT-02                   | HTML                                     | ✅   | `e2e/link-formats.spec.ts`: `html format: text is title, html is <a> without emoji`                           |
+| B-FMT-03                   | Markdown                                 | ✅   | `e2e/link-formats.spec.ts`: `markdown format: text is [title](url), no html`                                  |
+| B-FMT-04                   | HTML with Emoji                          | ✅   | `e2e/link-formats.spec.ts`: `htmlWithEmoji format: text is markdown, html has emoji + <a>`                    |
+| **サイト別処理**           |                                          |      |                                                                                                               |
+| B-SITE-01                  | Google Docs                              | ✅   | `e2e/site-title.spec.ts`: `Google Docs: title is テスト document`                                             |
+| B-SITE-02                  | Google Sheets                            | ✅   | `e2e/site-title.spec.ts`: `Google Sheets: title is テスト spreadsheet`                                        |
+| B-SITE-03                  | Google Slides                            | ✅   | `e2e/site-title.spec.ts`: `Google Slides: title is テスト presentation`                                       |
+| B-SITE-04                  | Google Drive                             | ✅   | `e2e/site-title.spec.ts`: `Google Drive: title is public folder`                                              |
+| B-SITE-05                  | GitHub Repos                             | ✅   | `e2e/site-title.spec.ts`: `GitHub Repo: emoji is :github:`                                                    |
+| B-SITE-06                  | GitHub Pull Requests                     | ✅   | `e2e/site-title.spec.ts`: `GitHub Pull Request: title is #<number> <text>`                                    |
+| B-SITE-07                  | GitHub Issues                            | ✅   | `e2e/site-title.spec.ts`: `GitHub Issue: title is #<number> <text>`                                           |
+| B-SITE-08                  | Jira Issues                              | ✅   | `e2e/site-title.spec.ts`: `Jira Issue: title is HIBERNATE-77 Support HQL in / not in`                         |
+| B-SITE-09                  | Asana Tasks                              | ✅   | `e2e/site-title.spec.ts`: `Asana Task (mocked): title from aria-label`                                        |
+| B-SITE-10                  | Backlog Issues                           | ✅   | `e2e/site-title.spec.ts`: `Backlog Issue (mocked): title from DOM selector`                                   |
+| B-SITE-11                  | Redmine Issues                           | ✅   | `e2e/site-title.spec.ts`: `Redmine Issue: title is Feature #642: OpenXR On Linux.`                            |
+| B-SITE-12                  | ReDoc (Swagger)                          | ✅   | `e2e/site-title.spec.ts`: `ReDoc: title is 法令本文取得API`                                                   |
+| B-SITE-13                  | 未登録サイト                             | ✅   | `e2e/core-commands.spec.ts`: example.com で検証                                                               |
+| **GitHub PR 状態別絵文字** |                                          |      |                                                                                                               |
+| B-GH-PR-01                 | PR状態別絵文字                           | ✅   | `e2e/site-title.spec.ts`: `GitHub Pull Request: status-specific emoji is used on a merged PR`                 |
+| B-GH-PR-02                 | Conversation の `data-status` 検出       | ✅   | `unit/getEmojiName.test.ts`: `maps data-status=%s to %s`                                                      |
+| B-GH-PR-03                 | Files Changed の `reviewable_state` 検出 | ✅   | `unit/getEmojiName.test.ts`: `falls back to reviewable_state text for GitHub Files Changed`                   |
+| B-GH-PR-04                 | 状態別絵文字のフォールバック             | ✅   | `unit/emojiResolver.test.ts`: `falls back to the default GitHub PR emoji when status emoji is not configured` |
+| **カスタムWebサイト**      |                                          |      |                                                                                                               |
+| B-CUSTOM-01                | カスタムスロット設定                     | ✅   | `e2e/popup.spec.ts`: `custom website regex + emoji is applied for matching URLs`                              |
+| B-CUSTOM-02                | カスタムがビルトインより優先             | ✅   | `e2e/popup.spec.ts`: `custom website regex takes priority over built-in site detection`                       |
+| B-CUSTOM-03                | カスタム正規表現マッチ時の絵文字適用     | ✅   | `e2e/popup.spec.ts`: `custom website regex + emoji is applied for matching URLs`                              |
+| **ポップアップ設定**       |                                          |      |                                                                                                               |
+| B-POPUP-01                 | 絵文字名の変更                           | ✅   | `e2e/popup.spec.ts`: `changing an emoji name persists and is used in copy`                                    |
+| B-POPUP-02                 | カスタムWebサイト設定                    | ✅   | `e2e/popup.spec.ts`: `custom website regex + emoji is applied for matching URLs`                              |
+| B-POPUP-03                 | リンクフォーマット選択                   | ✅   | `e2e/popup.spec.ts`: `selecting a link format radio persists to storage`                                      |
+| B-POPUP-04                 | リアルタイムストレージ保存               | ✅   | `e2e/popup.spec.ts`: 各テストでストレージ確認                                                                 |
+| **クリップボード**         |                                          |      |                                                                                                               |
+| B-CLIP-01                  | Clipboard API デュアルフォーマット       | ✅   | `e2e/core-commands.spec.ts`: text + HTML の両方を検証                                                         |
+| B-CLIP-02                  | HTTP フォールバック                      | ✅   | `e2e/http-site.spec.ts`: HTTP サイトでの3コマンドテスト                                                       |
+| B-CLIP-03                  | 選択範囲の保持                           | ✅   | `unit/clipboardFallback.test.ts`: `restores the previous selection range after execCommand fallback`          |
+| B-CLIP-04                  | Copy Link 出力フォーマット               | ✅   | `e2e/core-commands.spec.ts`                                                                                   |
+| B-CLIP-05                  | Copy Link for Slack 出力フォーマット     | ✅   | `e2e/core-commands.spec.ts`                                                                                   |
+| **Google Sheets 範囲**     |                                          |      |                                                                                                               |
+| B-RANGE-01                 | GID 抽出                                 | ✅   | `e2e/google-sheets.spec.ts`: `gid=0` の検証                                                                   |
+| B-RANGE-02                 | セル範囲抽出                             | ✅   | `e2e/google-sheets.spec.ts`: `range=C2:E4` の検証                                                             |
+| B-RANGE-03                 | リンク形式                               | ✅   | `e2e/google-sheets.spec.ts`                                                                                   |
+| B-RANGE-04                 | 非Sheetsページでno-op                    | ✅   | `e2e/google-sheets.spec.ts`: `on non-Sheets page does nothing`                                                |
+| B-RANGE-05                 | フォーマット別出力                       | ✅   | `e2e/link-formats.spec.ts`: 4フォーマット全テスト                                                             |
+| **トースト通知**           |                                          |      |                                                                                                               |
+| B-TOAST-01                 | コピー成功後に表示                       | ✅   | `e2e/toast.spec.ts`: `toast appears after copy-link`                                                          |
+| B-TOAST-02                 | 表示位置                                 | ✅   | `unit/toast-css.test.ts`: `positions the toast 24px from the bottom/left`                                     |
+| B-TOAST-03                 | 約3秒後の自動消去                        | ✅   | `e2e/toast.spec.ts`: `disappears after ~3s`                                                                   |
+| B-TOAST-04                 | Shadow DOM 隔離                          | ✅   | `unit/toastShadowDom.test.ts`: `places .copylink-dev-toast inside the shadow root, not in the main document`  |
+| **国際化**                 |                                          |      |                                                                                                               |
+| B-I18N-01                  | 英語サポート                             | ✅   | `unit/i18n.test.ts`: `en/messages.json contains all required keys`                                            |
+| B-I18N-02                  | 日本語サポート                           | ✅   | `unit/i18n.test.ts`: `ja/messages.json contains all required keys`                                            |
+| B-I18N-03                  | 中国語サポート                           | ✅   | `unit/i18n.test.ts`: `zh_CN/messages.json contains all required keys`                                         |
+| B-I18N-04                  | ポップアップ自動翻訳                     | ✅   | `unit/i18n.test.ts`: `every data-i18n attribute in popup.html references a key present in messages.json`      |
+| **エラーハンドリング**     |                                          |      |                                                                                                               |
+| B-ERR-01                   | タブ未発見時                             | ✅   | `unit/background.test.ts`: `logs an error and does nothing when no active tab is found`                       |
+| B-ERR-02                   | 非 http/https スキーム拒否               | ✅   | `unit/background.test.ts`: `rejects chrome:// URLs without injecting the content script`                      |
+| B-ERR-03                   | スクリプト注入失敗                       | ✅   | `unit/background.test.ts`: `logs error and does NOT send message when script injection fails`                 |
+| B-ERR-04                   | Clipboard API 失敗フォールバック         | ✅   | `unit/clipboardFallback.test.ts`: `attempts the execCommand fallback when Clipboard API fails`                |
+| B-ERR-05                   | 全方法失敗時の失敗表示                   | ✅   | `e2e/toast.spec.ts` + `unit/copyTextLinkCore.test.ts`: failure notification                                   |
+| **コンテントスクリプト**   |                                          |      |                                                                                                               |
+| B-CS-01                    | 重複注入防止                             | ✅   | `unit/content.test.ts`: `does NOT re-register the listener when the script is injected a second time`         |
+| B-CS-02                    | Chrome 動的注入                          | ⚠️   | 全 E2E テストで暗黙的に動作を確認                                                                             |
+| B-CS-03                    | Firefox 事前注入                         | ❌   | Playwright は Firefox 拡張のテストをサポートしていないため未対応                                              |

--- a/docs/behavior-test-coverage.md
+++ b/docs/behavior-test-coverage.md
@@ -42,7 +42,16 @@
 | B-SITE-12 | ReDoc (Swagger)      | `:swagger:`           | From the second span of the active label       |
 | B-SITE-13 | Unregistered sites   | (none)                | Uses `document.title` as-is                    |
 
-### 1.4 Custom Website Settings
+### 1.4 GitHub Pull Request Status Emoji
+
+| ID         | Behavior                                                                                           |
+| ---------- | -------------------------------------------------------------------------------------------------- |
+| B-GH-PR-01 | Pull request pages can use separate emojis for Draft, Open, Merged, and Closed states              |
+| B-GH-PR-02 | PR Conversation pages detect status from `data-status` (`draft`, `pullOpened`, `pullMerged`, etc.) |
+| B-GH-PR-03 | PR Files Changed pages fall back to `span[reviewable_state]` text (`Draft`, `Open`, etc.)          |
+| B-GH-PR-04 | If a status-specific emoji is unset, the default GitHub Pull Request emoji is used                 |
+
+### 1.5 Custom Website Settings
 
 | ID          | Behavior                                                                     |
 | ----------- | ---------------------------------------------------------------------------- |
@@ -50,7 +59,7 @@
 | B-CUSTOM-02 | Custom regex takes priority over built-in site detection                     |
 | B-CUSTOM-03 | When a custom regex matches the current URL, its configured emoji is applied |
 
-### 1.5 Popup Settings
+### 1.6 Popup Settings
 
 | ID         | Behavior                                                                 |
 | ---------- | ------------------------------------------------------------------------ |
@@ -59,7 +68,7 @@
 | B-POPUP-03 | Select the Google Sheets range link format via radio buttons (4 options) |
 | B-POPUP-04 | All setting changes are saved to `chrome.storage.local` in real time     |
 
-### 1.6 Clipboard Behavior
+### 1.7 Clipboard Behavior
 
 | ID        | Behavior                                                                    |
 | --------- | --------------------------------------------------------------------------- |
@@ -69,7 +78,7 @@
 | B-CLIP-04 | Copy Link: plain text = title, HTML = `<a>` tag                             |
 | B-CLIP-05 | Copy Link for Slack: plain text = Markdown, HTML = emoji + `<a>` tag        |
 
-### 1.7 Google Sheets Range Link
+### 1.8 Google Sheets Range Link
 
 | ID         | Behavior                                                        |
 | ---------- | --------------------------------------------------------------- |
@@ -79,7 +88,7 @@
 | B-RANGE-04 | Does nothing on non-Sheets pages                                |
 | B-RANGE-05 | Produces four output variants based on the selected link format |
 
-### 1.8 Toast Notifications
+### 1.9 Toast Notifications
 
 | ID         | Behavior                                                    |
 | ---------- | ----------------------------------------------------------- |
@@ -88,7 +97,7 @@
 | B-TOAST-03 | Auto-dismissed after ~3 seconds with a fade-out animation   |
 | B-TOAST-04 | Rendered inside a Shadow DOM, isolated from the page's CSS  |
 
-### 1.9 Internationalization (i18n)
+### 1.10 Internationalization (i18n)
 
 | ID        | Behavior                                                |
 | --------- | ------------------------------------------------------- |
@@ -97,7 +106,7 @@
 | B-I18N-03 | Simplified Chinese (zh_CN) locale support               |
 | B-I18N-04 | Automatic translation of popup labels via `[data-i18n]` |
 
-### 1.10 Error Handling
+### 1.11 Error Handling
 
 | ID       | Behavior                                                         |
 | -------- | ---------------------------------------------------------------- |
@@ -107,7 +116,7 @@
 | B-ERR-04 | Falls back to `execCommand` when the Clipboard API fails         |
 | B-ERR-05 | Shows a failure toast when all copy methods fail                 |
 
-### 1.11 Content Scripts
+### 1.12 Content Scripts
 
 | ID      | Behavior                                                              |
 | ------- | --------------------------------------------------------------------- |
@@ -136,70 +145,75 @@
 
 ### Coverage Mapping
 
-| Behavior ID                  | Behavior                            | Status | Test file / test name                                                                                        |
-| ---------------------------- | ----------------------------------- | ------ | ------------------------------------------------------------------------------------------------------------ |
-| **Core Commands**            |                                     |        |                                                                                                              |
-| B-CMD-01                     | Copy Link                           | ✅     | `e2e/core-commands.spec.ts`: `copy-link copies title as text and HTML anchor`                                |
-| B-CMD-02                     | Copy Link for Slack                 | ✅     | `e2e/core-commands.spec.ts`: `copy-link-for-slack copies markdown text and HTML with emoji`                  |
-| B-CMD-03                     | Copy Title                          | ✅     | `e2e/core-commands.spec.ts`: `copy-title copies only the page title as plain text`                           |
-| B-CMD-04                     | Copy Google Sheets Range            | ✅     | `e2e/google-sheets.spec.ts`: `copy-google-sheets-range copies URL with range parameter`                      |
-| **Link Formats**             |                                     |        |                                                                                                              |
-| B-FMT-01                     | Plain URL                           | ✅     | `e2e/link-formats.spec.ts`: `plainUrl format: text is URL only`                                              |
-| B-FMT-02                     | HTML                                | ✅     | `e2e/link-formats.spec.ts`: `html format: text is title, html is <a> without emoji`                          |
-| B-FMT-03                     | Markdown                            | ✅     | `e2e/link-formats.spec.ts`: `markdown format: text is [title](url), no html`                                 |
-| B-FMT-04                     | HTML with Emoji                     | ✅     | `e2e/link-formats.spec.ts`: `htmlWithEmoji format: text is markdown, html has emoji + <a>`                   |
-| **Site-specific Processing** |                                     |        |                                                                                                              |
-| B-SITE-01                    | Google Docs                         | ✅     | `e2e/site-title.spec.ts`: `Google Docs: title is テスト document`                                            |
-| B-SITE-02                    | Google Sheets                       | ✅     | `e2e/site-title.spec.ts`: `Google Sheets: title is テスト spreadsheet`                                       |
-| B-SITE-03                    | Google Slides                       | ✅     | `e2e/site-title.spec.ts`: `Google Slides: title is テスト presentation`                                      |
-| B-SITE-04                    | Google Drive                        | ✅     | `e2e/site-title.spec.ts`: `Google Drive: title is public folder`                                             |
-| B-SITE-05                    | GitHub Repos                        | ✅     | `e2e/site-title.spec.ts`: `GitHub Repo: emoji is :github:`                                                   |
-| B-SITE-06                    | GitHub Pull Requests                | ✅     | `e2e/site-title.spec.ts`: `GitHub Pull Request: title is #<number> <text>`                                   |
-| B-SITE-07                    | GitHub Issues                       | ✅     | `e2e/site-title.spec.ts`: `GitHub Issue: title is #<number> <text>`                                          |
-| B-SITE-08                    | Jira Issues                         | ✅     | `e2e/site-title.spec.ts`: `Jira Issue: title is HIBERNATE-77 Support HQL in / not in`                        |
-| B-SITE-09                    | Asana Tasks                         | ✅     | `e2e/site-title.spec.ts`: `Asana Task (mocked): title from aria-label`                                       |
-| B-SITE-10                    | Backlog Issues                      | ✅     | `e2e/site-title.spec.ts`: `Backlog Issue (mocked): title from DOM selector`                                  |
-| B-SITE-11                    | Redmine Issues                      | ✅     | `e2e/site-title.spec.ts`: `Redmine Issue: title is Feature #642: OpenXR On Linux.`                           |
-| B-SITE-12                    | ReDoc (Swagger)                     | ✅     | `e2e/site-title.spec.ts`: `ReDoc: title is 法令本文取得API`                                                  |
-| B-SITE-13                    | Unregistered sites                  | ✅     | `e2e/core-commands.spec.ts`: implicitly tested on example.com                                                |
-| **Custom Websites**          |                                     |        |                                                                                                              |
-| B-CUSTOM-01                  | Custom slot configuration           | ✅     | `e2e/popup.spec.ts`: `custom website regex + emoji is applied for matching URLs`                             |
-| B-CUSTOM-02                  | Custom takes priority over built-in | ✅     | `e2e/popup.spec.ts`: `custom website regex takes priority over built-in site detection`                      |
-| B-CUSTOM-03                  | Emoji applied on regex match        | ✅     | `e2e/popup.spec.ts`: `custom website regex + emoji is applied for matching URLs`                             |
-| **Popup Settings**           |                                     |        |                                                                                                              |
-| B-POPUP-01                   | Change emoji names                  | ✅     | `e2e/popup.spec.ts`: `changing an emoji name persists and is used in copy`                                   |
-| B-POPUP-02                   | Custom website configuration        | ✅     | `e2e/popup.spec.ts`: `custom website regex + emoji is applied for matching URLs`                             |
-| B-POPUP-03                   | Link format selection               | ✅     | `e2e/popup.spec.ts`: `selecting a link format radio persists to storage`                                     |
-| B-POPUP-04                   | Real-time storage persistence       | ✅     | `e2e/popup.spec.ts`: storage verified in each test                                                           |
-| **Clipboard**                |                                     |        |                                                                                                              |
-| B-CLIP-01                    | Clipboard API dual-format           | ✅     | `e2e/core-commands.spec.ts`: both text and HTML verified                                                     |
-| B-CLIP-02                    | HTTP fallback                       | ✅     | `e2e/http-site.spec.ts`: three commands tested on an HTTP site                                               |
-| B-CLIP-03                    | Selection preservation              | ✅     | `unit/clipboardFallback.test.ts`: `restores the previous selection range after execCommand fallback`         |
-| B-CLIP-04                    | Copy Link output format             | ✅     | `e2e/core-commands.spec.ts`                                                                                  |
-| B-CLIP-05                    | Copy Link for Slack output format   | ✅     | `e2e/core-commands.spec.ts`                                                                                  |
-| **Google Sheets Range**      |                                     |        |                                                                                                              |
-| B-RANGE-01                   | GID extraction                      | ✅     | `e2e/google-sheets.spec.ts`: `gid=0` verified                                                                |
-| B-RANGE-02                   | Cell range extraction               | ✅     | `e2e/google-sheets.spec.ts`: `range=C2:E4` verified                                                          |
-| B-RANGE-03                   | Link format                         | ✅     | `e2e/google-sheets.spec.ts`                                                                                  |
-| B-RANGE-04                   | No-op on non-Sheets pages           | ✅     | `e2e/google-sheets.spec.ts`: `on non-Sheets page does nothing`                                               |
-| B-RANGE-05                   | Format-variant outputs              | ✅     | `e2e/link-formats.spec.ts`: all 4 formats tested                                                             |
-| **Toast Notifications**      |                                     |        |                                                                                                              |
-| B-TOAST-01                   | Shown after successful copy         | ✅     | `e2e/toast.spec.ts`: `toast appears after copy-link`                                                         |
-| B-TOAST-02                   | Position                            | ✅     | `unit/toast-css.test.ts`: `positions the toast 24px from the bottom/left`                                    |
-| B-TOAST-03                   | Auto-dismissed after ~3s            | ✅     | `e2e/toast.spec.ts`: `disappears after ~3s`                                                                  |
-| B-TOAST-04                   | Shadow DOM isolation                | ✅     | `unit/toastShadowDom.test.ts`: `places .copylink-dev-toast inside the shadow root, not in the main document` |
-| **Internationalization**     |                                     |        |                                                                                                              |
-| B-I18N-01                    | English locale                      | ✅     | `unit/i18n.test.ts`: `en/messages.json contains all required keys`                                           |
-| B-I18N-02                    | Japanese locale                     | ✅     | `unit/i18n.test.ts`: `ja/messages.json contains all required keys`                                           |
-| B-I18N-03                    | Simplified Chinese locale           | ✅     | `unit/i18n.test.ts`: `zh_CN/messages.json contains all required keys`                                        |
-| B-I18N-04                    | Popup auto-translation              | ✅     | `unit/i18n.test.ts`: `every data-i18n attribute in popup.html references a key present in messages.json`     |
-| **Error Handling**           |                                     |        |                                                                                                              |
-| B-ERR-01                     | No active tab                       | ✅     | `unit/background.test.ts`: `logs an error and does nothing when no active tab is found`                      |
-| B-ERR-02                     | Non-http/https scheme rejected      | ✅     | `unit/background.test.ts`: `rejects chrome:// URLs without injecting the content script`                     |
-| B-ERR-03                     | Script injection failure            | ✅     | `unit/background.test.ts`: `logs error and does NOT send message when script injection fails`                |
-| B-ERR-04                     | Clipboard API failure fallback      | ✅     | `unit/clipboardFallback.test.ts`: `attempts the execCommand fallback when Clipboard API fails`               |
-| B-ERR-05                     | Failure toast when all methods fail | ✅     | `e2e/toast.spec.ts` + `unit/copyTextLinkCore.test.ts`: failure notification                                  |
-| **Content Scripts**          |                                     |        |                                                                                                              |
-| B-CS-01                      | Duplicate-injection guard           | ✅     | `unit/content.test.ts`: `does NOT re-register the listener when the script is injected a second time`        |
-| B-CS-02                      | Chrome dynamic injection            | ⚠️     | Implicitly verified by all E2E tests                                                                         |
-| B-CS-03                      | Firefox pre-injected script         | ❌     | Playwright does not support testing Firefox extensions                                                       |
+| Behavior ID                  | Behavior                                   | Status | Test file / test name                                                                                         |
+| ---------------------------- | ------------------------------------------ | ------ | ------------------------------------------------------------------------------------------------------------- |
+| **Core Commands**            |                                            |        |                                                                                                               |
+| B-CMD-01                     | Copy Link                                  | ✅     | `e2e/core-commands.spec.ts`: `copy-link copies title as text and HTML anchor`                                 |
+| B-CMD-02                     | Copy Link for Slack                        | ✅     | `e2e/core-commands.spec.ts`: `copy-link-for-slack copies markdown text and HTML with emoji`                   |
+| B-CMD-03                     | Copy Title                                 | ✅     | `e2e/core-commands.spec.ts`: `copy-title copies only the page title as plain text`                            |
+| B-CMD-04                     | Copy Google Sheets Range                   | ✅     | `e2e/google-sheets.spec.ts`: `copy-google-sheets-range copies URL with range parameter`                       |
+| **Link Formats**             |                                            |        |                                                                                                               |
+| B-FMT-01                     | Plain URL                                  | ✅     | `e2e/link-formats.spec.ts`: `plainUrl format: text is URL only`                                               |
+| B-FMT-02                     | HTML                                       | ✅     | `e2e/link-formats.spec.ts`: `html format: text is title, html is <a> without emoji`                           |
+| B-FMT-03                     | Markdown                                   | ✅     | `e2e/link-formats.spec.ts`: `markdown format: text is [title](url), no html`                                  |
+| B-FMT-04                     | HTML with Emoji                            | ✅     | `e2e/link-formats.spec.ts`: `htmlWithEmoji format: text is markdown, html has emoji + <a>`                    |
+| **Site-specific Processing** |                                            |        |                                                                                                               |
+| B-SITE-01                    | Google Docs                                | ✅     | `e2e/site-title.spec.ts`: `Google Docs: title is テスト document`                                             |
+| B-SITE-02                    | Google Sheets                              | ✅     | `e2e/site-title.spec.ts`: `Google Sheets: title is テスト spreadsheet`                                        |
+| B-SITE-03                    | Google Slides                              | ✅     | `e2e/site-title.spec.ts`: `Google Slides: title is テスト presentation`                                       |
+| B-SITE-04                    | Google Drive                               | ✅     | `e2e/site-title.spec.ts`: `Google Drive: title is public folder`                                              |
+| B-SITE-05                    | GitHub Repos                               | ✅     | `e2e/site-title.spec.ts`: `GitHub Repo: emoji is :github:`                                                    |
+| B-SITE-06                    | GitHub Pull Requests                       | ✅     | `e2e/site-title.spec.ts`: `GitHub Pull Request: title is #<number> <text>`                                    |
+| B-SITE-07                    | GitHub Issues                              | ✅     | `e2e/site-title.spec.ts`: `GitHub Issue: title is #<number> <text>`                                           |
+| B-SITE-08                    | Jira Issues                                | ✅     | `e2e/site-title.spec.ts`: `Jira Issue: title is HIBERNATE-77 Support HQL in / not in`                         |
+| B-SITE-09                    | Asana Tasks                                | ✅     | `e2e/site-title.spec.ts`: `Asana Task (mocked): title from aria-label`                                        |
+| B-SITE-10                    | Backlog Issues                             | ✅     | `e2e/site-title.spec.ts`: `Backlog Issue (mocked): title from DOM selector`                                   |
+| B-SITE-11                    | Redmine Issues                             | ✅     | `e2e/site-title.spec.ts`: `Redmine Issue: title is Feature #642: OpenXR On Linux.`                            |
+| B-SITE-12                    | ReDoc (Swagger)                            | ✅     | `e2e/site-title.spec.ts`: `ReDoc: title is 法令本文取得API`                                                   |
+| B-SITE-13                    | Unregistered sites                         | ✅     | `e2e/core-commands.spec.ts`: implicitly tested on example.com                                                 |
+| **GitHub PR Status Emoji**   |                                            |        |                                                                                                               |
+| B-GH-PR-01                   | Status-specific PR emoji                   | ✅     | `e2e/site-title.spec.ts`: `GitHub Pull Request: status-specific emoji is used on a merged PR`                 |
+| B-GH-PR-02                   | Conversation `data-status` detection       | ✅     | `unit/getEmojiName.test.ts`: `maps data-status=%s to %s`                                                      |
+| B-GH-PR-03                   | Files Changed `reviewable_state` detection | ✅     | `unit/getEmojiName.test.ts`: `falls back to reviewable_state text for GitHub Files Changed`                   |
+| B-GH-PR-04                   | Status emoji fallback                      | ✅     | `unit/emojiResolver.test.ts`: `falls back to the default GitHub PR emoji when status emoji is not configured` |
+| **Custom Websites**          |                                            |        |                                                                                                               |
+| B-CUSTOM-01                  | Custom slot configuration                  | ✅     | `e2e/popup.spec.ts`: `custom website regex + emoji is applied for matching URLs`                              |
+| B-CUSTOM-02                  | Custom takes priority over built-in        | ✅     | `e2e/popup.spec.ts`: `custom website regex takes priority over built-in site detection`                       |
+| B-CUSTOM-03                  | Emoji applied on regex match               | ✅     | `e2e/popup.spec.ts`: `custom website regex + emoji is applied for matching URLs`                              |
+| **Popup Settings**           |                                            |        |                                                                                                               |
+| B-POPUP-01                   | Change emoji names                         | ✅     | `e2e/popup.spec.ts`: `changing an emoji name persists and is used in copy`                                    |
+| B-POPUP-02                   | Custom website configuration               | ✅     | `e2e/popup.spec.ts`: `custom website regex + emoji is applied for matching URLs`                              |
+| B-POPUP-03                   | Link format selection                      | ✅     | `e2e/popup.spec.ts`: `selecting a link format radio persists to storage`                                      |
+| B-POPUP-04                   | Real-time storage persistence              | ✅     | `e2e/popup.spec.ts`: storage verified in each test                                                            |
+| **Clipboard**                |                                            |        |                                                                                                               |
+| B-CLIP-01                    | Clipboard API dual-format                  | ✅     | `e2e/core-commands.spec.ts`: both text and HTML verified                                                      |
+| B-CLIP-02                    | HTTP fallback                              | ✅     | `e2e/http-site.spec.ts`: three commands tested on an HTTP site                                                |
+| B-CLIP-03                    | Selection preservation                     | ✅     | `unit/clipboardFallback.test.ts`: `restores the previous selection range after execCommand fallback`          |
+| B-CLIP-04                    | Copy Link output format                    | ✅     | `e2e/core-commands.spec.ts`                                                                                   |
+| B-CLIP-05                    | Copy Link for Slack output format          | ✅     | `e2e/core-commands.spec.ts`                                                                                   |
+| **Google Sheets Range**      |                                            |        |                                                                                                               |
+| B-RANGE-01                   | GID extraction                             | ✅     | `e2e/google-sheets.spec.ts`: `gid=0` verified                                                                 |
+| B-RANGE-02                   | Cell range extraction                      | ✅     | `e2e/google-sheets.spec.ts`: `range=C2:E4` verified                                                           |
+| B-RANGE-03                   | Link format                                | ✅     | `e2e/google-sheets.spec.ts`                                                                                   |
+| B-RANGE-04                   | No-op on non-Sheets pages                  | ✅     | `e2e/google-sheets.spec.ts`: `on non-Sheets page does nothing`                                                |
+| B-RANGE-05                   | Format-variant outputs                     | ✅     | `e2e/link-formats.spec.ts`: all 4 formats tested                                                              |
+| **Toast Notifications**      |                                            |        |                                                                                                               |
+| B-TOAST-01                   | Shown after successful copy                | ✅     | `e2e/toast.spec.ts`: `toast appears after copy-link`                                                          |
+| B-TOAST-02                   | Position                                   | ✅     | `unit/toast-css.test.ts`: `positions the toast 24px from the bottom/left`                                     |
+| B-TOAST-03                   | Auto-dismissed after ~3s                   | ✅     | `e2e/toast.spec.ts`: `disappears after ~3s`                                                                   |
+| B-TOAST-04                   | Shadow DOM isolation                       | ✅     | `unit/toastShadowDom.test.ts`: `places .copylink-dev-toast inside the shadow root, not in the main document`  |
+| **Internationalization**     |                                            |        |                                                                                                               |
+| B-I18N-01                    | English locale                             | ✅     | `unit/i18n.test.ts`: `en/messages.json contains all required keys`                                            |
+| B-I18N-02                    | Japanese locale                            | ✅     | `unit/i18n.test.ts`: `ja/messages.json contains all required keys`                                            |
+| B-I18N-03                    | Simplified Chinese locale                  | ✅     | `unit/i18n.test.ts`: `zh_CN/messages.json contains all required keys`                                         |
+| B-I18N-04                    | Popup auto-translation                     | ✅     | `unit/i18n.test.ts`: `every data-i18n attribute in popup.html references a key present in messages.json`      |
+| **Error Handling**           |                                            |        |                                                                                                               |
+| B-ERR-01                     | No active tab                              | ✅     | `unit/background.test.ts`: `logs an error and does nothing when no active tab is found`                       |
+| B-ERR-02                     | Non-http/https scheme rejected             | ✅     | `unit/background.test.ts`: `rejects chrome:// URLs without injecting the content script`                      |
+| B-ERR-03                     | Script injection failure                   | ✅     | `unit/background.test.ts`: `logs error and does NOT send message when script injection fails`                 |
+| B-ERR-04                     | Clipboard API failure fallback             | ✅     | `unit/clipboardFallback.test.ts`: `attempts the execCommand fallback when Clipboard API fails`                |
+| B-ERR-05                     | Failure toast when all methods fail        | ✅     | `e2e/toast.spec.ts` + `unit/copyTextLinkCore.test.ts`: failure notification                                   |
+| **Content Scripts**          |                                            |        |                                                                                                               |
+| B-CS-01                      | Duplicate-injection guard                  | ✅     | `unit/content.test.ts`: `does NOT re-register the listener when the script is injected a second time`         |
+| B-CS-02                      | Chrome dynamic injection                   | ⚠️     | Implicitly verified by all E2E tests                                                                          |
+| B-CS-03                      | Firefox pre-injected script                | ❌     | Playwright does not support testing Firefox extensions                                                        |

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test:unit": "vitest run"
   },
   "devDependencies": {
-    "@playwright/test": "^1.59.1",
+    "@playwright/test": "^1.61.1",
     "@types/chrome": "^0.1.40",
     "@types/node": "^25.6.0",
     "happy-dom": "^20.9.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,97 +1,3 @@
----
-lockfileVersion: '9.0'
-
-importers:
-
-  .:
-    configDependencies: {}
-    packageManagerDependencies:
-      '@pnpm/exe':
-        specifier: 10.33.0
-        version: 10.33.0
-      pnpm:
-        specifier: 10.33.0
-        version: 10.33.0
-
-packages:
-
-  '@pnpm/exe@10.33.0':
-    resolution: {integrity: sha512-sGsjztJBelzVMd0RhceDJ3p8Hk7eBcpu4G/TF6REzIvNdkKyxDT0czc1BWyo8Kbg+U0OBtK/TAGXN7Art4rTdg==}
-    hasBin: true
-
-  '@pnpm/linux-arm64@10.33.0':
-    resolution: {integrity: sha512-oYb5NxEyImqaTkLVX/7jL59m9Vfmd07iLWzr4Pg2LIk4XEtAllNcnksNHcp5Uf+lFk/BggtpOdvC84TG3VnbFw==}
-    cpu: [arm64]
-    os: [linux]
-    hasBin: true
-
-  '@pnpm/linux-x64@10.33.0':
-    resolution: {integrity: sha512-JYD2GXDF2roKpvTg5s032lYcUcT9lMedYlzxoqitWTjKlkMhl2gXRYpiDHdi2mWC5nFOJYlgYbUuy6jh3rXhng==}
-    cpu: [x64]
-    os: [linux]
-    hasBin: true
-
-  '@pnpm/macos-arm64@10.33.0':
-    resolution: {integrity: sha512-3w9Pqpw0swnAbnEdAKumMuKj+TPaGratnqC49bC41vjR1pNs0UMwVdOxiIROUMQy5OHKPx0IH/wOOP0hkhJd+g==}
-    cpu: [arm64]
-    os: [darwin]
-    hasBin: true
-
-  '@pnpm/macos-x64@10.33.0':
-    resolution: {integrity: sha512-SBeiLjU/9ORMIXAMsD6+Ltaaesniwh49FeFcG6kA64Zxr30U9SyzeZDnNOyWCGFjHeCmGfzCnSpNEN4VNo827g==}
-    cpu: [x64]
-    os: [darwin]
-    hasBin: true
-
-  '@pnpm/win-arm64@10.33.0':
-    resolution: {integrity: sha512-8X3NQqmfNVZ+dCu+EfD7ZkAgDgIKKdAgBBKcvhvMoMJq/nWHOfqDLxewE9TQ7qzVLuUKG/9b/xBVRVjdtDOm0w==}
-    cpu: [arm64]
-    os: [win32]
-    hasBin: true
-
-  '@pnpm/win-x64@10.33.0':
-    resolution: {integrity: sha512-wiPVvxmTuB6FFn+rZ4FfSk1WTn+cxiQ7MTJEEz1k9VZLN/yZujGrv/WLYH2JcwzVTgObfmQuBKeNgEUavEL0Qg==}
-    cpu: [x64]
-    os: [win32]
-    hasBin: true
-
-  pnpm@10.33.0:
-    resolution: {integrity: sha512-EFaLtKavtYyes2MNqQzJUWQXq+vT+rvmc58K55VyjaFJHp21pUTHatjrdXD1xLs9bGN7LLQb/c20f6gjyGSTGQ==}
-    engines: {node: '>=18.12'}
-    hasBin: true
-
-snapshots:
-
-  '@pnpm/exe@10.33.0':
-    optionalDependencies:
-      '@pnpm/linux-arm64': 10.33.0
-      '@pnpm/linux-x64': 10.33.0
-      '@pnpm/macos-arm64': 10.33.0
-      '@pnpm/macos-x64': 10.33.0
-      '@pnpm/win-arm64': 10.33.0
-      '@pnpm/win-x64': 10.33.0
-
-  '@pnpm/linux-arm64@10.33.0':
-    optional: true
-
-  '@pnpm/linux-x64@10.33.0':
-    optional: true
-
-  '@pnpm/macos-arm64@10.33.0':
-    optional: true
-
-  '@pnpm/macos-x64@10.33.0':
-    optional: true
-
-  '@pnpm/win-arm64@10.33.0':
-    optional: true
-
-  '@pnpm/win-x64@10.33.0':
-    optional: true
-
-  pnpm@10.33.0: {}
-
----
 lockfileVersion: '9.0'
 
 settings:
@@ -103,8 +9,8 @@ importers:
   .:
     devDependencies:
       '@playwright/test':
-        specifier: ^1.59.1
-        version: 1.59.1
+        specifier: ^1.61.1
+        version: 1.61.1
       '@types/chrome':
         specifier: ^0.1.40
         version: 0.1.40
@@ -430,8 +336,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@playwright/test@1.59.1':
-    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
+  '@playwright/test@1.61.1':
+    resolution: {integrity: sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -764,13 +670,13 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
-  playwright-core@1.59.1:
-    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+  playwright-core@1.61.1:
+    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.59.1:
-    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+  playwright@1.61.1:
+    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -1092,9 +998,9 @@ snapshots:
   '@oxlint/binding-win32-x64-msvc@1.60.0':
     optional: true
 
-  '@playwright/test@1.59.1':
+  '@playwright/test@1.61.1':
     dependencies:
-      playwright: 1.59.1
+      playwright: 1.61.1
 
   '@rolldown/binding-android-arm64@1.0.0-rc.15':
     optional: true
@@ -1386,11 +1292,11 @@ snapshots:
 
   picomatch@4.0.4: {}
 
-  playwright-core@1.59.1: {}
+  playwright-core@1.61.1: {}
 
-  playwright@1.59.1:
+  playwright@1.61.1:
     dependencies:
-      playwright-core: 1.59.1
+      playwright-core: 1.61.1
     optionalDependencies:
       fsevents: 2.3.2
 

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -65,6 +65,18 @@
   "githubPullRequest": {
     "message": "GitHub Pull Request"
   },
+  "githubDraftPullRequest": {
+    "message": "GitHub Draft Pull Request"
+  },
+  "githubOpenPullRequest": {
+    "message": "GitHub Open Pull Request"
+  },
+  "githubMergedPullRequest": {
+    "message": "GitHub Merged Pull Request"
+  },
+  "githubClosedPullRequest": {
+    "message": "GitHub Closed Pull Request"
+  },
   "githubIssue": {
     "message": "GitHub Issue"
   },

--- a/public/_locales/ja/messages.json
+++ b/public/_locales/ja/messages.json
@@ -65,6 +65,18 @@
   "githubPullRequest": {
     "message": "GitHub Pull Request"
   },
+  "githubDraftPullRequest": {
+    "message": "GitHub Draft Pull Request"
+  },
+  "githubOpenPullRequest": {
+    "message": "GitHub Open Pull Request"
+  },
+  "githubMergedPullRequest": {
+    "message": "GitHub Merged Pull Request"
+  },
+  "githubClosedPullRequest": {
+    "message": "GitHub Closed Pull Request"
+  },
   "githubIssue": {
     "message": "GitHub Issue"
   },

--- a/public/_locales/zh_CN/messages.json
+++ b/public/_locales/zh_CN/messages.json
@@ -65,6 +65,18 @@
   "githubPullRequest": {
     "message": "GitHub Pull Request"
   },
+  "githubDraftPullRequest": {
+    "message": "GitHub Draft Pull Request"
+  },
+  "githubOpenPullRequest": {
+    "message": "GitHub Open Pull Request"
+  },
+  "githubMergedPullRequest": {
+    "message": "GitHub Merged Pull Request"
+  },
+  "githubClosedPullRequest": {
+    "message": "GitHub Closed Pull Request"
+  },
   "githubIssue": {
     "message": "GitHub Issue"
   },

--- a/public/popup.html
+++ b/public/popup.html
@@ -56,6 +56,46 @@
           id="emojiName-github-pull-request"
           placeholder="Emoji Name"
         />
+        <label
+          for="emojiName-github-draft-pull-request"
+          data-i18n="githubDraftPullRequest"
+          >GitHub Draft Pull Request</label
+        >
+        <input
+          type="text"
+          id="emojiName-github-draft-pull-request"
+          placeholder="Fallback to GitHub Pull Request"
+        />
+        <label
+          for="emojiName-github-open-pull-request"
+          data-i18n="githubOpenPullRequest"
+          >GitHub Open Pull Request</label
+        >
+        <input
+          type="text"
+          id="emojiName-github-open-pull-request"
+          placeholder="Fallback to GitHub Pull Request"
+        />
+        <label
+          for="emojiName-github-merged-pull-request"
+          data-i18n="githubMergedPullRequest"
+          >GitHub Merged Pull Request</label
+        >
+        <input
+          type="text"
+          id="emojiName-github-merged-pull-request"
+          placeholder="Fallback to GitHub Pull Request"
+        />
+        <label
+          for="emojiName-github-closed-pull-request"
+          data-i18n="githubClosedPullRequest"
+          >GitHub Closed Pull Request</label
+        >
+        <input
+          type="text"
+          id="emojiName-github-closed-pull-request"
+          placeholder="Fallback to GitHub Pull Request"
+        />
         <label for="emojiName-github-issue" data-i18n="githubIssue"
           >GitHub Issue</label
         >

--- a/src/scripts/getEmojiName.ts
+++ b/src/scripts/getEmojiName.ts
@@ -1,10 +1,74 @@
 import type { CustomRegexes, EmojiNameRecord } from "../types/types";
-import { type PageContext, resolveEmojiName } from "../shared/emojiResolver";
+import {
+  type GitHubPullRequestStatus,
+  type PageContext,
+  resolveEmojiName,
+} from "../shared/emojiResolver";
 import { DEFAULT_EMOJI_NAMES } from "../shared/constants";
 
 type StorageData = {
   emojiNames?: Partial<EmojiNameRecord>;
   copylinkdevCustomRegexes?: Partial<CustomRegexes>;
+};
+
+const parseGitHubPullRequestStatus = (
+  value: string | null | undefined,
+): GitHubPullRequestStatus | undefined => {
+  const normalized = value
+    ?.trim()
+    .replace(/^status:\s*/i, "")
+    .trim()
+    .toLowerCase();
+  if (normalized === undefined) {
+    return undefined;
+  }
+  switch (normalized) {
+    case "draft":
+      return "draft";
+    case "pullopened":
+    case "open":
+      return "open";
+    case "pullmerged":
+    case "merged":
+      return "merged";
+    case "pullclosed":
+    case "closed":
+      return "closed";
+    default:
+      return undefined;
+  }
+};
+
+const githubPullRequestStatusSelector = "header [data-status]";
+const githubReviewableStateSelector = "span[reviewable_state]";
+
+export const getGitHubPullRequestStatus = ():
+  | GitHubPullRequestStatus
+  | undefined => {
+  const statusElement = document.querySelector<HTMLElement>(
+    githubPullRequestStatusSelector,
+  );
+  const dataStatus = parseGitHubPullRequestStatus(
+    statusElement?.dataset.status,
+  );
+  if (dataStatus !== undefined) {
+    return dataStatus;
+  }
+
+  // TODO: This will be unneeded as GitHub updates its DOM structure
+  const reviewableStateElements = document.querySelectorAll<HTMLElement>(
+    githubReviewableStateSelector,
+  );
+  for (const reviewableStateElement of reviewableStateElements) {
+    const status = parseGitHubPullRequestStatus(
+      reviewableStateElement.textContent,
+    );
+    if (status !== undefined) {
+      return status;
+    }
+  }
+
+  return undefined;
 };
 
 const buildPageContext = (): PageContext => ({
@@ -13,6 +77,7 @@ const buildPageContext = (): PageContext => ({
   pathname: window.location.pathname,
   documentBodyId: document.body.id,
   documentTitle: document.title,
+  githubPullRequestStatus: getGitHubPullRequestStatus(),
   hasRedmineFooter:
     document.querySelector("#footer a")?.textContent?.includes("Redmine") ??
     false,

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -19,6 +19,10 @@ export const EMOJI_KEYS = [
   "googleDrive",
   "github",
   "githubPullRequest",
+  "githubDraftPullRequest",
+  "githubOpenPullRequest",
+  "githubMergedPullRequest",
+  "githubClosedPullRequest",
   "githubIssue",
   "jiraIssue",
   "asanaTask",
@@ -48,6 +52,13 @@ export const CUSTOM_REGEX_KEYS = [
   "customRegex5",
 ] as const;
 
+export const GITHUB_PULL_REQUEST_STATUS_EMOJI_KEYS = [
+  "githubDraftPullRequest",
+  "githubOpenPullRequest",
+  "githubMergedPullRequest",
+  "githubClosedPullRequest",
+] as const satisfies Array<EmojiKeys>;
+
 export const DEFAULT_EMOJI_NAMES: EmojiNameRecord = {
   googleSheets: ":google_sheets:",
   googleDocs: ":google_docs:",
@@ -55,6 +66,10 @@ export const DEFAULT_EMOJI_NAMES: EmojiNameRecord = {
   googleDrive: ":google_drive_2:",
   github: ":github:",
   githubPullRequest: ":open_pull_request:",
+  githubDraftPullRequest: ":open_pull_request:",
+  githubOpenPullRequest: ":open_pull_request:",
+  githubMergedPullRequest: ":open_pull_request:",
+  githubClosedPullRequest: ":open_pull_request:",
   githubIssue: ":open_issue:",
   jiraIssue: ":jira:",
   asanaTask: ":asana:",
@@ -75,6 +90,10 @@ const EMOJI_ELEMENT_RECORD: EmojiElementRecord = {
   googleDrive: "emojiName-google-drive",
   github: "emojiName-github",
   githubPullRequest: "emojiName-github-pull-request",
+  githubDraftPullRequest: "emojiName-github-draft-pull-request",
+  githubOpenPullRequest: "emojiName-github-open-pull-request",
+  githubMergedPullRequest: "emojiName-github-merged-pull-request",
+  githubClosedPullRequest: "emojiName-github-closed-pull-request",
   githubIssue: "emojiName-github-issue",
   jiraIssue: "emojiName-jira-issue",
   asanaTask: "emojiName-asana-task",

--- a/src/shared/emojiResolver.ts
+++ b/src/shared/emojiResolver.ts
@@ -3,7 +3,9 @@ import {
   CUSTOM_REGEX_KEYS,
   DEFAULT_EMOJI_NAMES,
 } from "./constants";
-import type { CustomRegexes, EmojiNameRecord } from "../types/types";
+import type { CustomRegexes, EmojiKeys, EmojiNameRecord } from "../types/types";
+
+export type GitHubPullRequestStatus = "draft" | "open" | "merged" | "closed";
 
 export type PageContext = {
   href: string;
@@ -11,6 +13,7 @@ export type PageContext = {
   pathname: string;
   documentBodyId?: string;
   documentTitle?: string;
+  githubPullRequestStatus?: GitHubPullRequestStatus;
   hasRedmineFooter?: boolean;
   hasRedocWrap?: boolean;
 };
@@ -26,6 +29,13 @@ const getEmojiGetter =
   (key: keyof EmojiNameRecord) =>
     emojiNames[key] ?? defaults[key];
 
+const githubPullRequestStatusEmojiKeys = {
+  draft: "githubDraftPullRequest",
+  open: "githubOpenPullRequest",
+  merged: "githubMergedPullRequest",
+  closed: "githubClosedPullRequest",
+} as const satisfies Record<GitHubPullRequestStatus, EmojiKeys>;
+
 export const resolveEmojiName = (
   ctx: PageContext,
   deps: EmojiResolverDeps,
@@ -34,6 +44,19 @@ export const resolveEmojiName = (
   const customRegexes = deps.customRegexes ?? {};
   const defaults = deps.defaults ?? DEFAULT_EMOJI_NAMES;
   const getEmoji = getEmojiGetter(emojiNames, defaults);
+  const getGitHubPullRequestEmoji = (): string => {
+    const status = ctx.githubPullRequestStatus;
+    if (status === undefined) {
+      return getEmoji("githubPullRequest");
+    }
+
+    const statusEmoji = emojiNames[githubPullRequestStatusEmojiKeys[status]];
+    if (statusEmoji !== undefined && statusEmoji.length > 0) {
+      return statusEmoji;
+    }
+
+    return getEmoji("githubPullRequest");
+  };
 
   for (const [index, regexKey] of CUSTOM_REGEX_KEYS.entries()) {
     const websiteKey = CUSTOM_EMOJI_KEYS[index];
@@ -72,7 +95,7 @@ export const resolveEmojiName = (
   if (ctx.hostname === "github.com") {
     switch (pathParts[3]) {
       case "pull":
-        return getEmoji("githubPullRequest");
+        return getGitHubPullRequestEmoji();
       case "issues":
         return getEmoji("githubIssue");
       default:

--- a/src/shared/popup/emojiSettings.ts
+++ b/src/shared/popup/emojiSettings.ts
@@ -2,6 +2,7 @@ import {
   CUSTOM_REGEX_KEYS,
   DEFAULT_EMOJI_NAMES,
   EMOJI_KEYS,
+  GITHUB_PULL_REQUEST_STATUS_EMOJI_KEYS,
 } from "../constants";
 import type {
   CustomRegexKeys,
@@ -10,6 +11,10 @@ import type {
   EmojiName,
   EmojiNameRecord,
 } from "../../types/types";
+
+const fallbackEmojiKeys = new Set<EmojiKeys>(
+  GITHUB_PULL_REQUEST_STATUS_EMOJI_KEYS,
+);
 
 export const isEmojiFormat = (value: string): value is EmojiName =>
   /^:.*:$/.test(value);
@@ -35,6 +40,9 @@ export const buildEmojiNames = (
   const result: Partial<EmojiNameRecord> = {};
   for (const key of EMOJI_KEYS) {
     const rawValue = values[key] ?? "";
+    if (fallbackEmojiKeys.has(key) && rawValue.trim().length === 0) {
+      continue;
+    }
     result[key] = normalizeEmojiValue(rawValue, defaults[key]);
   }
   return result;
@@ -57,7 +65,17 @@ export const getInitialEmojiValues = (
   stored?: Partial<EmojiNameRecord>,
   defaults: EmojiNameRecord = DEFAULT_EMOJI_NAMES,
 ): EmojiNameRecord => {
-  const result = { ...defaults } as EmojiNameRecord;
+  const result = { ...defaults };
+
+  const storedGithubPullRequest = stored?.githubPullRequest;
+  const githubPullRequestFallback =
+    storedGithubPullRequest !== undefined && storedGithubPullRequest.length > 0
+      ? normalizeEmojiValue(storedGithubPullRequest, defaults.githubPullRequest)
+      : defaults.githubPullRequest;
+  for (const key of fallbackEmojiKeys) {
+    result[key] = githubPullRequestFallback;
+  }
+
   if (stored) {
     for (const key of EMOJI_KEYS) {
       const value = stored[key];

--- a/tests/e2e/site-title.spec.ts
+++ b/tests/e2e/site-title.spec.ts
@@ -31,6 +31,37 @@ test.describe("Site-specific title formatting and emoji", () => {
     expect(html).toContain(":open_pull_request:");
   });
 
+  test("GitHub Pull Request: status-specific emoji is used on a merged PR", async ({
+    sw,
+    context,
+  }) => {
+    await sw.evaluate(async () => {
+      await chrome.storage.local.set({
+        emojiNames: {
+          githubPullRequest: ":pull_request:",
+          githubMergedPullRequest: ":merged_pull_request:",
+        },
+      });
+    });
+
+    const page = await context.newPage();
+    await page.goto("https://github.com/wintorse/copylink-dev/pull/60", {
+      waitUntil: "domcontentloaded",
+    });
+    await page.waitForSelector("header [data-status]", { timeout: 15_000 });
+
+    await triggerCommand(sw, page, "copy-link-for-slack");
+
+    const html = await readClipboardHtml(page);
+    expect(html).not.toBeNull();
+    expect(html).toContain(":merged_pull_request:");
+    expect(html).not.toContain(":pull_request:");
+
+    await sw.evaluate(async () => {
+      await chrome.storage.local.remove("emojiNames");
+    });
+  });
+
   test("GitHub Issue: title is #<number> <text>", async ({ sw, context }) => {
     const page = await context.newPage();
     await page.goto("https://github.com/wintorse/copylink-dev/issues/54", {

--- a/tests/unit/emojiResolver.test.ts
+++ b/tests/unit/emojiResolver.test.ts
@@ -51,6 +51,37 @@ describe("resolveEmojiName – built-in site detection", () => {
     ).toBe(":open_pull_request:");
   });
 
+  it("uses GitHub PR status emoji when configured", () => {
+    expect(
+      resolveEmojiName(
+        ctx("https://github.com/owner/repo/pull/1", {
+          githubPullRequestStatus: "merged",
+        }),
+        {
+          emojiNames: {
+            githubPullRequest: ":pull_request:",
+            githubMergedPullRequest: ":merged_pull_request:",
+          },
+        },
+      ),
+    ).toBe(":merged_pull_request:");
+  });
+
+  it("falls back to the default GitHub PR emoji when status emoji is not configured", () => {
+    expect(
+      resolveEmojiName(
+        ctx("https://github.com/owner/repo/pull/1", {
+          githubPullRequestStatus: "closed",
+        }),
+        {
+          emojiNames: {
+            githubPullRequest: ":pull_request:",
+          },
+        },
+      ),
+    ).toBe(":pull_request:");
+  });
+
   it("returns :open_issue: for GitHub Issue", () => {
     expect(
       resolveEmojiName(ctx("https://github.com/owner/repo/issues/1"), {}),

--- a/tests/unit/emojiSettings.test.ts
+++ b/tests/unit/emojiSettings.test.ts
@@ -1,0 +1,33 @@
+import {
+  buildEmojiNames,
+  getInitialEmojiValues,
+} from "../../src/shared/popup/emojiSettings";
+import { describe, expect, it } from "vitest";
+
+describe("emojiSettings – GitHub PR status fallback", () => {
+  it("omits blank GitHub PR status emoji values so they can fall back", () => {
+    expect(
+      buildEmojiNames({
+        githubPullRequest: ":pull_request:",
+        githubMergedPullRequest: "",
+      }),
+    ).not.toHaveProperty("githubMergedPullRequest");
+  });
+
+  it("stores configured GitHub PR status emoji values", () => {
+    expect(
+      buildEmojiNames({
+        githubMergedPullRequest: "merged_pull_request",
+      }),
+    ).toHaveProperty("githubMergedPullRequest", ":merged_pull_request:");
+  });
+
+  it("shows blank initial values for unset GitHub PR status emoji fields", () => {
+    const values = getInitialEmojiValues({
+      githubPullRequest: ":pull_request:",
+    });
+
+    expect(values.githubPullRequest).toBe(":pull_request:");
+    expect(values.githubMergedPullRequest).toBe("");
+  });
+});

--- a/tests/unit/emojiSettings.test.ts
+++ b/tests/unit/emojiSettings.test.ts
@@ -22,12 +22,25 @@ describe("emojiSettings – GitHub PR status fallback", () => {
     ).toHaveProperty("githubMergedPullRequest", ":merged_pull_request:");
   });
 
-  it("shows blank initial values for unset GitHub PR status emoji fields", () => {
+  it("falls back unset GitHub PR status emoji fields to the githubPullRequest emoji", () => {
     const values = getInitialEmojiValues({
       githubPullRequest: ":pull_request:",
     });
 
     expect(values.githubPullRequest).toBe(":pull_request:");
-    expect(values.githubMergedPullRequest).toBe("");
+    expect(values.githubMergedPullRequest).toBe(":pull_request:");
+    expect(values.githubDraftPullRequest).toBe(":pull_request:");
+    expect(values.githubOpenPullRequest).toBe(":pull_request:");
+    expect(values.githubClosedPullRequest).toBe(":pull_request:");
+  });
+
+  it("uses a configured GitHub PR status emoji instead of the fallback", () => {
+    const values = getInitialEmojiValues({
+      githubPullRequest: ":pull_request:",
+      githubMergedPullRequest: ":merged_pull_request:",
+    });
+
+    expect(values.githubMergedPullRequest).toBe(":merged_pull_request:");
+    expect(values.githubDraftPullRequest).toBe(":pull_request:");
   });
 });

--- a/tests/unit/getEmojiName.test.ts
+++ b/tests/unit/getEmojiName.test.ts
@@ -1,0 +1,71 @@
+// @vitest-environment happy-dom
+import { beforeEach, describe, expect, it } from "vitest";
+import { getGitHubPullRequestStatus } from "../../src/scripts/getEmojiName";
+
+describe("getGitHubPullRequestStatus", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("ignores GitHub header menu text and reads the PR status data attribute", () => {
+    document.body.innerHTML = `
+      <header>
+        <button><span>Open Menu</span></button>
+        <div class="d-flex flex-items-center gap-2 flex-shrink-0">
+          <span data-status="pullOpened"><svg aria-hidden="true"></svg></span>
+        </div>
+      </header>
+    `;
+
+    expect(getGitHubPullRequestStatus()).toBe("open");
+  });
+
+  it("reads status from the data-status attribute before other text", () => {
+    document.body.innerHTML = `
+      <header>
+        <span data-status="pullMerged" aria-label="Status: Open">Open</span>
+      </header>
+    `;
+
+    expect(getGitHubPullRequestStatus()).toBe("merged");
+  });
+
+  it.each([
+    ["draft", "draft"],
+    ["pullOpened", "open"],
+    ["pullMerged", "merged"],
+    ["pullClosed", "closed"],
+  ] as const)("maps data-status=%s to %s", (dataStatus, expected) => {
+    document.body.innerHTML = `
+      <header>
+        <span data-status="${dataStatus}"></span>
+      </header>
+    `;
+
+    expect(getGitHubPullRequestStatus()).toBe(expected);
+  });
+
+  it("falls back to reviewable_state text for GitHub Files Changed", () => {
+    document.body.innerHTML = `
+      <main>
+        <span reviewable_state="ready">Open</span>
+        <span reviewable_state="ready">Open</span>
+      </main>
+    `;
+
+    expect(getGitHubPullRequestStatus()).toBe("open");
+  });
+
+  it("prefers data-status over reviewable_state text", () => {
+    document.body.innerHTML = `
+      <header>
+        <span data-status="pullMerged"></span>
+      </header>
+      <main>
+        <span reviewable_state="ready">Open</span>
+      </main>
+    `;
+
+    expect(getGitHubPullRequestStatus()).toBe("merged");
+  });
+});


### PR DESCRIPTION
Add a support for GitHub Pull Request status-specific emoji (Draft, Open, Merged, Closed), and upgrades the Playwright test dependency to the latest version.

* When the four emojis are not set, they fallbacks to GitHub PR emoji.
* Added unit tests and E2E tests 
* Upgraded `@playwright/test` from version 1.59.1 to 1.61.1 for bug fixes