### PR TITLE
♻️ Move GitHubPullRequestStatus logic to a separate module

### DIFF
--- a/src/scripts/getEmojiName.ts
+++ b/src/scripts/getEmojiName.ts
@@ -1,74 +1,11 @@
 import type { CustomRegexes, EmojiNameRecord } from "../types/types";
-import {
-  type GitHubPullRequestStatus,
-  type PageContext,
-  resolveEmojiName,
-} from "../shared/emojiResolver";
+import { type PageContext, resolveEmojiName } from "../shared/emojiResolver";
 import { DEFAULT_EMOJI_NAMES } from "../shared/constants";
+import { getGitHubPullRequestStatus } from "../shared/githubPullRequestStatus";
 
 type StorageData = {
   emojiNames?: Partial<EmojiNameRecord>;
   copylinkdevCustomRegexes?: Partial<CustomRegexes>;
-};
-
-const parseGitHubPullRequestStatus = (
-  value: string | null | undefined,
-): GitHubPullRequestStatus | undefined => {
-  const normalized = value
-    ?.trim()
-    .replace(/^status:\s*/i, "")
-    .trim()
-    .toLowerCase();
-  if (normalized === undefined) {
-    return undefined;
-  }
-  switch (normalized) {
-    case "draft":
-      return "draft";
-    case "pullopened":
-    case "open":
-      return "open";
-    case "pullmerged":
-    case "merged":
-      return "merged";
-    case "pullclosed":
-    case "closed":
-      return "closed";
-    default:
-      return undefined;
-  }
-};
-
-const githubPullRequestStatusSelector = "header [data-status]";
-const githubReviewableStateSelector = "span[reviewable_state]";
-
-export const getGitHubPullRequestStatus = ():
-  | GitHubPullRequestStatus
-  | undefined => {
-  const statusElement = document.querySelector<HTMLElement>(
-    githubPullRequestStatusSelector,
-  );
-  const dataStatus = parseGitHubPullRequestStatus(
-    statusElement?.dataset.status,
-  );
-  if (dataStatus !== undefined) {
-    return dataStatus;
-  }
-
-  // TODO: This will be unneeded as GitHub updates its DOM structure
-  const reviewableStateElements = document.querySelectorAll<HTMLElement>(
-    githubReviewableStateSelector,
-  );
-  for (const reviewableStateElement of reviewableStateElements) {
-    const status = parseGitHubPullRequestStatus(
-      reviewableStateElement.textContent,
-    );
-    if (status !== undefined) {
-      return status;
-    }
-  }
-
-  return undefined;
 };
 
 const buildPageContext = (): PageContext => ({

--- a/src/shared/emojiResolver.ts
+++ b/src/shared/emojiResolver.ts
@@ -4,8 +4,7 @@ import {
   DEFAULT_EMOJI_NAMES,
 } from "./constants";
 import type { CustomRegexes, EmojiKeys, EmojiNameRecord } from "../types/types";
-
-export type GitHubPullRequestStatus = "draft" | "open" | "merged" | "closed";
+import type { GitHubPullRequestStatus } from "./githubPullRequestStatus";
 
 export type PageContext = {
   href: string;

--- a/src/shared/githubPullRequestStatus.ts
+++ b/src/shared/githubPullRequestStatus.ts
@@ -1,0 +1,61 @@
+export type GitHubPullRequestStatus = "draft" | "open" | "merged" | "closed";
+
+const parseGitHubPullRequestStatus = (
+  value: string | null | undefined,
+): GitHubPullRequestStatus | undefined => {
+  const normalized = value
+    ?.trim()
+    .replace(/^status:\s*/i, "")
+    .trim()
+    .toLowerCase();
+  if (normalized === undefined) {
+    return undefined;
+  }
+  switch (normalized) {
+    case "draft":
+      return "draft";
+    case "pullopened":
+    case "open":
+      return "open";
+    case "pullmerged":
+    case "merged":
+      return "merged";
+    case "pullclosed":
+    case "closed":
+      return "closed";
+    default:
+      return undefined;
+  }
+};
+
+const githubPullRequestStatusSelector = "header [data-status]";
+const githubReviewableStateSelector = "span[reviewable_state]";
+
+export const getGitHubPullRequestStatus = ():
+  | GitHubPullRequestStatus
+  | undefined => {
+  const statusElement = document.querySelector<HTMLElement>(
+    githubPullRequestStatusSelector,
+  );
+  const dataStatus = parseGitHubPullRequestStatus(
+    statusElement?.dataset.status,
+  );
+  if (dataStatus !== undefined) {
+    return dataStatus;
+  }
+
+  // TODO: This will be unneeded as GitHub updates its DOM structure
+  const reviewableStateElements = document.querySelectorAll<HTMLElement>(
+    githubReviewableStateSelector,
+  );
+  for (const reviewableStateElement of reviewableStateElements) {
+    const status = parseGitHubPullRequestStatus(
+      reviewableStateElement.textContent,
+    );
+    if (status !== undefined) {
+      return status;
+    }
+  }
+
+  return undefined;
+};

--- a/tests/unit/getEmojiName.test.ts
+++ b/tests/unit/getEmojiName.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 import { beforeEach, describe, expect, it } from "vitest";
-import { getGitHubPullRequestStatus } from "../../src/scripts/getEmojiName";
+import { getGitHubPullRequestStatus } from "../../src/shared/githubPullRequestStatus";
 
 describe("getGitHubPullRequestStatus", () => {
   beforeEach(() => {


### PR DESCRIPTION
`getGitHubPullRequestStatus` logic is shared between `copylink-dev-user-js`, so it should be inside `/src/shared/` directory.

- [x] e2e tests passed