### PR TITLE
♻️ Update GitHub PR/Issues ID extraction logic

### DIFF
--- a/src/shared/getFormattedTitle.ts
+++ b/src/shared/getFormattedTitle.ts
@@ -14,7 +14,7 @@ const getGitHubTitle = (): string => {
   const titleElement =
     document.querySelector<HTMLElement>("h1 > *:first-child");
   const title = titleElement?.textContent?.trim();
-  const idMatch = window.location.pathname.match(/\/pull\/(\d+)/);
+  const idMatch = window.location.pathname.match(/\/(?:pull|issues)\/(\d+)/);
   const id = idMatch ? `#${idMatch[1]}` : undefined;
   return title !== undefined && title !== "" && id !== undefined
     ? `${id} ${title}`

--- a/src/shared/getFormattedTitle.ts
+++ b/src/shared/getFormattedTitle.ts
@@ -13,12 +13,10 @@ const getGoogleDriveTitle = (): string => {
 const getGitHubTitle = (): string => {
   const titleElement =
     document.querySelector<HTMLElement>("h1 > *:first-child");
-  const idElement =
-    document.querySelector<HTMLSpanElement>("h1 > *:nth-child(2) > span") ??
-    document.querySelector<HTMLSpanElement>("h1 > *:nth-child(2)");
   const title = titleElement?.textContent?.trim();
-  const id = idElement?.textContent?.trim();
-  return title !== undefined && title !== "" && id !== undefined && id !== ""
+  const idMatch = window.location.pathname.match(/\/pull\/(\d+)/);
+  const id = idMatch ? `#${idMatch[1]}` : undefined;
+  return title !== undefined && title !== "" && id !== undefined
     ? `${id} ${title}`
     : document.title;
 };


### PR DESCRIPTION
Updates the logic for generating GitHub titles in the `getFormattedTitle.ts` utility. The main improvement is a more robust way of extracting the PR or issue number from the URL instead of relying on DOM structure, which increases reliability across GitHub UI changes.

**GitHub title extraction improvements:**

* Updated `getGitHubTitle` to extract the PR or issue number directly from the URL path using a regular expression, instead of querying the DOM for the ID element. This makes the function more resilient to GitHub UI changes.