### PR TITLE
Implement retry logic and fix test flakiness in HTTP tests

### DIFF
--- a/src/scripts/getEmojiName.ts
+++ b/src/scripts/getEmojiName.ts
@@ -16,7 +16,7 @@ const buildPageContext = (): PageContext => ({
   documentTitle: document.title,
   githubPullRequestStatus: getGitHubPullRequestStatus(),
   hasRedmineFooter:
-    document.querySelector("#footer a")?.textContent?.includes("Redmine") ??
+    document.querySelector("#footer")?.textContent?.includes("Redmine") ??
     false,
   hasRedocWrap: !!document.querySelector(".redoc-wrap"),
 });

--- a/tests/e2e/fixtures.ts
+++ b/tests/e2e/fixtures.ts
@@ -76,6 +76,60 @@ export const SHEETS_URL =
 export const SHEETS_URL_WITH_RANGE = `${SHEETS_URL}#gid=0&range=C2:E4`;
 
 /**
+ * True for transient navigation failures (timeouts, connection blips) that
+ * are worth retrying, as opposed to deterministic errors (bad URL, blocked
+ * request) that would fail the same way on every attempt.
+ *
+ * @param error - The error thrown by `page.goto`.
+ * @returns Whether the error is transient and worth retrying.
+ */
+function isTransientNavigationError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  if (error.name === "TimeoutError") {
+    return true;
+  }
+  return /net::ERR_(CONNECTION_(RESET|REFUSED|CLOSED|ABORTED)|NETWORK_CHANGED|TIMED_OUT|INTERNET_DISCONNECTED|NAME_NOT_RESOLVED|ADDRESS_UNREACHABLE)/.test(
+    error.message,
+  );
+}
+
+/**
+ * Navigate to a URL, retrying on transient failures (e.g. navigation
+ * timeouts, connection resets). Non-transient errors are rethrown
+ * immediately without retrying.
+ *
+ * Useful for real external sites whose first request in a test run can be
+ * slow (cold DNS/TLS handshake, CI network warm-up), causing occasional
+ * flaky timeouts that a simple retry resolves.
+ *
+ * @param page - The Playwright page to navigate.
+ * @param url - The URL to navigate to.
+ * @param options - Options forwarded to `page.goto`.
+ * @param retries - Number of additional attempts after a transient failure.
+ * @returns A promise that resolves with the result of `page.goto` when navigation succeeds, or rejects if
+ */
+export async function gotoWithRetry(
+  page: Page,
+  url: string,
+  options?: Parameters<Page["goto"]>[1],
+  retries = 2,
+): Promise<ReturnType<Page["goto"]>> {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      const result = await page.goto(url, options);
+      return result;
+    } catch (error) {
+      if (attempt >= retries || !isTransientNavigationError(error)) {
+        throw error;
+      }
+    }
+    await new Promise((resolve) => setTimeout(resolve, 500)); // Wait a bit before retrying
+  }
+}
+
+/**
  * Trigger a copylink-dev command via the extension's service worker.
  * Mirrors what `background.ts` does on `chrome.commands.onCommand`:
  * query active tab → inject content script → send message.

--- a/tests/e2e/http-site.spec.ts
+++ b/tests/e2e/http-site.spec.ts
@@ -1,5 +1,6 @@
 import {
   expect,
+  gotoWithRetry,
   readClipboardHtml,
   readClipboardText,
   test,
@@ -26,7 +27,10 @@ test.describe("HTTP site (navigator.clipboard unavailable)", () => {
     context,
   }) => {
     const httpPage = await context.newPage();
-    await httpPage.goto(HTTP_URL, { waitUntil: "domcontentloaded" });
+    await gotoWithRetry(httpPage, HTTP_URL, {
+      waitUntil: "domcontentloaded",
+      timeout: 10_000,
+    });
 
     // Open an HTTPS page to read clipboard, since navigator.clipboard
     // is unavailable in the HTTP page context.
@@ -49,7 +53,10 @@ test.describe("HTTP site (navigator.clipboard unavailable)", () => {
 
   test("copy-title copies plain text title", async ({ sw, context }) => {
     const httpPage = await context.newPage();
-    await httpPage.goto(HTTP_URL, { waitUntil: "domcontentloaded" });
+    await gotoWithRetry(httpPage, HTTP_URL, {
+      waitUntil: "domcontentloaded",
+      timeout: 10_000,
+    });
 
     const clipboardPage = await context.newPage();
     await clipboardPage.goto("https://example.com", {
@@ -67,7 +74,10 @@ test.describe("HTTP site (navigator.clipboard unavailable)", () => {
     context,
   }) => {
     const httpPage = await context.newPage();
-    await httpPage.goto(HTTP_URL, { waitUntil: "domcontentloaded" });
+    await gotoWithRetry(httpPage, HTTP_URL, {
+      waitUntil: "domcontentloaded",
+      timeout: 10_000,
+    });
 
     const clipboardPage = await context.newPage();
     await clipboardPage.goto("https://example.com", {

--- a/tests/e2e/site-title.spec.ts
+++ b/tests/e2e/site-title.spec.ts
@@ -133,7 +133,28 @@ test.describe("Site-specific title formatting and emoji", () => {
     sw,
     context,
   }) => {
+    // redmine.openspace3d.com is a small, third-party-hosted Redmine
+    // instance that is intermittently unreliable (slow responses / 503s),
+    // which made this test flaky. Mock the response like the Asana/Backlog
+    // tests below so we verify our own title-extraction logic without
+    // depending on that server's uptime.
     const page = await context.newPage();
+    await page.route(
+      "https://redmine.openspace3d.com/issues/642",
+      async (route) => {
+        await route.fulfill({
+          contentType: "text/html",
+          body: `<!DOCTYPE html>
+<html><head><title>Feature #642: OpenXR On Linux. - OpenSpace3D - Redmine</title></head>
+<body>
+  <div id="content">
+    <h2>Feature #642</h2>
+    <h3>OpenXR On Linux.</h3>
+  </div>
+</body></html>`,
+        });
+      },
+    );
     await page.goto("https://redmine.openspace3d.com/issues/642", {
       waitUntil: "domcontentloaded",
     });
@@ -259,7 +280,7 @@ test.describe("Site-specific title formatting and emoji", () => {
     const page = await context.newPage();
     await page.goto(
       "https://drive.google.com/drive/folders/1Om4PwxNNjGDODM8EZXFP-aRHSL1NyJg0",
-      { waitUntil: "load", timeout: 30_000 },
+      { waitUntil: "load", timeout: 20_000 },
     );
 
     // Wait for title to update — Google Drive loads folder names asynchronously.
@@ -267,7 +288,7 @@ test.describe("Site-specific title formatting and emoji", () => {
     await page.waitForFunction(
       (expected) => document.title.includes(expected),
       "public folder",
-      { timeout: 15_000 },
+      { timeout: 20_000 },
     );
 
     await triggerCommand(sw, page, "copy-link");


### PR DESCRIPTION
resolves #107 

I fixed the following E2E test because it was flaky.

- `tests/e2e/http-site.spec.ts:24:3` › HTTP site (navigator.clipboard unavailable) › copy-link copies title as text and HTML anchor
  - Since the initial access to the external site `kmoni.bosai.go.jp` can sometimes be slow due to cold DNS/TLS, I added a gotoWithRetry helper to `fixtures.ts`, which automatically retries on failure and extends the timeout.
- `tests/e2e/site-title.spec.ts:132:3` › Site-specific title formatting and emoji › Redmine Issue: title is Feature #642: OpenXR On Linux.
  - I changed the Redmine tests from accessing the live site to mocking them using page.route.
  - I've also slightly relaxed the criteria for determining if a site is Redmine.
- `tests/e2e/site-title.spec.ts:279:3` › Site-specific title formatting and emoji › Google Drive: title is public folder
  - I adjusted the timeouts.