### PR TITLE
✨ Add E2E test workflow with scheduled execution

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,6 +1,10 @@
 name: E2E Test
 
 on:
+  pull_request:
+    branches:
+      - main
+
   schedule:
     # every day 3:00 JST
     - cron: "0 3 * * *"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,32 @@
+name: E2E Test
+
+on:
+  schedule:
+    # 奇数日の 3:00 JST
+    - cron: "0 3 1-31/2 * *"
+      timezone: "Asia/Tokyo"
+
+  workflow_dispatch:
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7.0.1
+
+      - uses: pnpm/setup@v2.0.2
+        with:
+          runtime: node@26
+          cache: true
+          install: false
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Run E2E tests
+        run: pnpm test

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,8 +2,8 @@ name: E2E Test
 
 on:
   schedule:
-    # 奇数日の 3:00 JST
-    - cron: "0 3 1-31/2 * *"
+    # every day 3:00 JST
+    - cron: "0 3 * * *"
       timezone: "Asia/Tokyo"
 
   workflow_dispatch:


### PR DESCRIPTION
To address situations where E2E tests that were passing until yesterday suddenly fail due to changes in external sites or browser updates, I added a workflow to run the E2E tests on a regular schedule.
In addition, I've also made it so that E2E tests run on PRs to main as well.