### PR TITLE
✨ Add import and export functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /node_modules
 /dist
 /test-results
+/.pnpm-store

--- a/docs/behavior-test-coverage-ja.md
+++ b/docs/behavior-test-coverage-ja.md
@@ -61,14 +61,14 @@
 
 ### 1.6 ポップアップ設定
 
-| ID         | 機能                                                     |
-| ---------- | -------------------------------------------------------- |
-| B-POPUP-01 | 13個のビルトイン絵文字名の入力・変更                     |
-| B-POPUP-02 | 5つのカスタムWebサイト（正規表現 + 絵文字）の設定        |
-| B-POPUP-03 | Google Sheetsリンクフォーマットのラジオボタン選択（4種） |
-| B-POPUP-04 | 設定変更が `chrome.storage.local` にリアルタイム保存     |
+| ID         | 機能                                                               |
+| ---------- | ------------------------------------------------------------------ |
+| B-POPUP-01 | 13個のビルトイン絵文字名の入力・変更                               |
+| B-POPUP-02 | 5つのカスタムWebサイト（正規表現 + 絵文字）の設定                  |
+| B-POPUP-03 | Google Sheetsリンクフォーマットのラジオボタン選択（4種）           |
+| B-POPUP-04 | 設定変更が `chrome.storage.local` にリアルタイム保存               |
 | B-POPUP-05 | 絵文字名とカスタム正規表現をJSONとしてクリップボードへエクスポート |
-| B-POPUP-06 | JSON設定をインポートし、保存してフォームへ反映             |
+| B-POPUP-06 | JSON設定をインポートし、保存してフォームへ反映                     |
 
 ### 1.7 クリップボード動作
 
@@ -188,7 +188,7 @@
 | B-POPUP-03                 | リンクフォーマット選択                   | ✅   | `e2e/popup.spec.ts`: `selecting a link format radio persists to storage`                                      |
 | B-POPUP-04                 | リアルタイムストレージ保存               | ✅   | `e2e/popup.spec.ts`: 各テストでストレージ確認                                                                 |
 | B-POPUP-05                 | 設定のエクスポート                       | ✅   | `e2e/popup.spec.ts`: `exports emoji names and custom regexes to the clipboard`                                |
-| B-POPUP-06                 | 設定のインポート                         | ✅   | `e2e/popup.spec.ts`: `imports settings, saves them, and refreshes the form inputs`                             |
+| B-POPUP-06                 | 設定のインポート                         | ✅   | `e2e/popup.spec.ts`: `imports settings, saves them, and refreshes the form inputs`                            |
 | **クリップボード**         |                                          |      |                                                                                                               |
 | B-CLIP-01                  | Clipboard API デュアルフォーマット       | ✅   | `e2e/core-commands.spec.ts`: text + HTML の両方を検証                                                         |
 | B-CLIP-02                  | HTTP フォールバック                      | ✅   | `e2e/http-site.spec.ts`: HTTP サイトでの3コマンドテスト                                                       |

--- a/docs/behavior-test-coverage-ja.md
+++ b/docs/behavior-test-coverage-ja.md
@@ -67,6 +67,8 @@
 | B-POPUP-02 | 5つのカスタムWebサイト（正規表現 + 絵文字）の設定        |
 | B-POPUP-03 | Google Sheetsリンクフォーマットのラジオボタン選択（4種） |
 | B-POPUP-04 | 設定変更が `chrome.storage.local` にリアルタイム保存     |
+| B-POPUP-05 | 絵文字名とカスタム正規表現をJSONとしてクリップボードへエクスポート |
+| B-POPUP-06 | JSON設定をインポートし、保存してフォームへ反映             |
 
 ### 1.7 クリップボード動作
 
@@ -185,6 +187,8 @@
 | B-POPUP-02                 | カスタムWebサイト設定                    | ✅   | `e2e/popup.spec.ts`: `custom website regex + emoji is applied for matching URLs`                              |
 | B-POPUP-03                 | リンクフォーマット選択                   | ✅   | `e2e/popup.spec.ts`: `selecting a link format radio persists to storage`                                      |
 | B-POPUP-04                 | リアルタイムストレージ保存               | ✅   | `e2e/popup.spec.ts`: 各テストでストレージ確認                                                                 |
+| B-POPUP-05                 | 設定のエクスポート                       | ✅   | `e2e/popup.spec.ts`: `exports emoji names and custom regexes to the clipboard`                                |
+| B-POPUP-06                 | 設定のインポート                         | ✅   | `e2e/popup.spec.ts`: `imports settings, saves them, and refreshes the form inputs`                             |
 | **クリップボード**         |                                          |      |                                                                                                               |
 | B-CLIP-01                  | Clipboard API デュアルフォーマット       | ✅   | `e2e/core-commands.spec.ts`: text + HTML の両方を検証                                                         |
 | B-CLIP-02                  | HTTP フォールバック                      | ✅   | `e2e/http-site.spec.ts`: HTTP サイトでの3コマンドテスト                                                       |

--- a/docs/behavior-test-coverage.md
+++ b/docs/behavior-test-coverage.md
@@ -67,6 +67,8 @@
 | B-POPUP-02 | Configure up to 5 custom websites (regex + emoji)                        |
 | B-POPUP-03 | Select the Google Sheets range link format via radio buttons (4 options) |
 | B-POPUP-04 | All setting changes are saved to `chrome.storage.local` in real time     |
+| B-POPUP-05 | Export emoji names and custom regexes as JSON to the clipboard             |
+| B-POPUP-06 | Import JSON settings, save them, and refresh the form inputs               |
 
 ### 1.7 Clipboard Behavior
 
@@ -185,6 +187,8 @@
 | B-POPUP-02                   | Custom website configuration               | ✅     | `e2e/popup.spec.ts`: `custom website regex + emoji is applied for matching URLs`                              |
 | B-POPUP-03                   | Link format selection                      | ✅     | `e2e/popup.spec.ts`: `selecting a link format radio persists to storage`                                      |
 | B-POPUP-04                   | Real-time storage persistence              | ✅     | `e2e/popup.spec.ts`: storage verified in each test                                                            |
+| B-POPUP-05                   | Export settings                          | ✅     | `e2e/popup.spec.ts`: `exports emoji names and custom regexes to the clipboard`                                |
+| B-POPUP-06                   | Import settings                          | ✅     | `e2e/popup.spec.ts`: `imports settings, saves them, and refreshes the form inputs`                             |
 | **Clipboard**                |                                            |        |                                                                                                               |
 | B-CLIP-01                    | Clipboard API dual-format                  | ✅     | `e2e/core-commands.spec.ts`: both text and HTML verified                                                      |
 | B-CLIP-02                    | HTTP fallback                              | ✅     | `e2e/http-site.spec.ts`: three commands tested on an HTTP site                                                |

--- a/docs/behavior-test-coverage.md
+++ b/docs/behavior-test-coverage.md
@@ -67,8 +67,8 @@
 | B-POPUP-02 | Configure up to 5 custom websites (regex + emoji)                        |
 | B-POPUP-03 | Select the Google Sheets range link format via radio buttons (4 options) |
 | B-POPUP-04 | All setting changes are saved to `chrome.storage.local` in real time     |
-| B-POPUP-05 | Export emoji names and custom regexes as JSON to the clipboard             |
-| B-POPUP-06 | Import JSON settings, save them, and refresh the form inputs               |
+| B-POPUP-05 | Export emoji names and custom regexes as JSON to the clipboard           |
+| B-POPUP-06 | Import JSON settings, save them, and refresh the form inputs             |
 
 ### 1.7 Clipboard Behavior
 
@@ -187,8 +187,8 @@
 | B-POPUP-02                   | Custom website configuration               | ✅     | `e2e/popup.spec.ts`: `custom website regex + emoji is applied for matching URLs`                              |
 | B-POPUP-03                   | Link format selection                      | ✅     | `e2e/popup.spec.ts`: `selecting a link format radio persists to storage`                                      |
 | B-POPUP-04                   | Real-time storage persistence              | ✅     | `e2e/popup.spec.ts`: storage verified in each test                                                            |
-| B-POPUP-05                   | Export settings                          | ✅     | `e2e/popup.spec.ts`: `exports emoji names and custom regexes to the clipboard`                                |
-| B-POPUP-06                   | Import settings                          | ✅     | `e2e/popup.spec.ts`: `imports settings, saves them, and refreshes the form inputs`                             |
+| B-POPUP-05                   | Export settings                            | ✅     | `e2e/popup.spec.ts`: `exports emoji names and custom regexes to the clipboard`                                |
+| B-POPUP-06                   | Import settings                            | ✅     | `e2e/popup.spec.ts`: `imports settings, saves them, and refreshes the form inputs`                            |
 | **Clipboard**                |                                            |        |                                                                                                               |
 | B-CLIP-01                    | Clipboard API dual-format                  | ✅     | `e2e/core-commands.spec.ts`: both text and HTML verified                                                      |
 | B-CLIP-02                    | HTTP fallback                              | ✅     | `e2e/http-site.spec.ts`: three commands tested on an HTTP site                                                |

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -62,6 +62,9 @@
   "importConfirmButton": {
     "message": "Overwrite and save settings"
   },
+  "importFailure": {
+    "message": "Failed to import. Please check the format of the data."
+  },
   "googleSheets": {
     "message": "Google Sheets"
   },

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -66,16 +66,16 @@
     "message": "GitHub Pull Request"
   },
   "githubDraftPullRequest": {
-    "message": "GitHub Draft Pull Request"
+    "message": "GitHub Pull Request (Draft)"
   },
   "githubOpenPullRequest": {
-    "message": "GitHub Open Pull Request"
+    "message": "GitHub Pull Request (Open)"
   },
   "githubMergedPullRequest": {
-    "message": "GitHub Merged Pull Request"
+    "message": "GitHub Pull Request (Merged)"
   },
   "githubClosedPullRequest": {
-    "message": "GitHub Closed Pull Request"
+    "message": "GitHub Pull Request (Closed)"
   },
   "githubIssue": {
     "message": "GitHub Issue"

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -44,8 +44,23 @@
   "slackEmojiSettings": {
     "message": "Slack Emoji Settings"
   },
-  "changeEmojiNames": {
-    "message": "Update emoji names"
+  "import": {
+    "message": "Import"
+  },
+  "export": {
+    "message": "Export"
+  },
+  "exportSuccess": {
+    "message": "Emoji names and custom regexes exported to clipboard"
+  },
+  "exportFailure": {
+    "message": "Failed to export emoji names and custom regexes"
+  },
+  "importJsonLabel": {
+    "message": "Import other user's settings"
+  },
+  "importConfirmButton": {
+    "message": "Overwrite and save settings"
   },
   "googleSheets": {
     "message": "Google Sheets"

--- a/public/_locales/ja/messages.json
+++ b/public/_locales/ja/messages.json
@@ -62,6 +62,9 @@
   "importConfirmButton": {
     "message": "上書きして設定を保存"
   },
+  "importFailure": {
+    "message": "インポートに失敗しました。データの形式を確認してください。"
+  },
   "googleSheets": {
     "message": "Google スプレッドシート"
   },

--- a/public/_locales/ja/messages.json
+++ b/public/_locales/ja/messages.json
@@ -44,8 +44,23 @@
   "slackEmojiSettings": {
     "message": "Slack 絵文字設定"
   },
-  "changeEmojiNames": {
-    "message": "絵文字名の変更"
+  "import": {
+    "message": "インポート"
+  },
+  "export": {
+    "message": "エクスポート"
+  },
+  "exportSuccess": {
+    "message": "絵文字名とカスタム正規表現をクリップボードにコピーしました"
+  },
+  "exportFailure": {
+    "message": "絵文字名とカスタム正規表現のエクスポートに失敗しました"
+  },
+  "importJsonLabel": {
+    "message": "他のユーザーの設定をインポート"
+  },
+  "importConfirmButton": {
+    "message": "上書きして設定を保存"
   },
   "googleSheets": {
     "message": "Google スプレッドシート"

--- a/public/_locales/ja/messages.json
+++ b/public/_locales/ja/messages.json
@@ -66,16 +66,16 @@
     "message": "GitHub Pull Request"
   },
   "githubDraftPullRequest": {
-    "message": "GitHub Draft Pull Request"
+    "message": "GitHub Pull Request (Draft)"
   },
   "githubOpenPullRequest": {
-    "message": "GitHub Open Pull Request"
+    "message": "GitHub Pull Request (Open)"
   },
   "githubMergedPullRequest": {
-    "message": "GitHub Merged Pull Request"
+    "message": "GitHub Pull Request (Merged)"
   },
   "githubClosedPullRequest": {
-    "message": "GitHub Closed Pull Request"
+    "message": "GitHub Pull Request (Closed)"
   },
   "githubIssue": {
     "message": "GitHub Issue"

--- a/public/_locales/zh_CN/messages.json
+++ b/public/_locales/zh_CN/messages.json
@@ -66,16 +66,16 @@
     "message": "GitHub Pull Request"
   },
   "githubDraftPullRequest": {
-    "message": "GitHub Draft Pull Request"
+    "message": "GitHub Pull Request (Draft)"
   },
   "githubOpenPullRequest": {
-    "message": "GitHub Open Pull Request"
+    "message": "GitHub Pull Request (Open)"
   },
   "githubMergedPullRequest": {
-    "message": "GitHub Merged Pull Request"
+    "message": "GitHub Pull Request (Merged)"
   },
   "githubClosedPullRequest": {
-    "message": "GitHub Closed Pull Request"
+    "message": "GitHub Pull Request (Closed)"
   },
   "githubIssue": {
     "message": "GitHub Issue"

--- a/public/_locales/zh_CN/messages.json
+++ b/public/_locales/zh_CN/messages.json
@@ -62,6 +62,9 @@
   "importConfirmButton": {
     "message": "覆盖并保存设置"
   },
+  "importFailure": {
+    "message": "导入失败。请检查数据格式。"
+  },
   "googleSheets": {
     "message": "Google表格"
   },

--- a/public/_locales/zh_CN/messages.json
+++ b/public/_locales/zh_CN/messages.json
@@ -44,8 +44,23 @@
   "slackEmojiSettings": {
     "message": "Slack表情符号设置"
   },
-  "changeEmojiNames": {
-    "message": "更改表情符号名称"
+  "import": {
+    "message": "导入"
+  },
+  "export": {
+    "message": "导出"
+  },
+  "exportSuccess": {
+    "message": "表情符号名称和自定义正则表达式已导出到剪贴板"
+  },
+  "exportFailure": {
+    "message": "导出表情符号名称和自定义正则表达式失败"
+  },
+  "importJsonLabel": {
+    "message": "导入其他用户的设置"
+  },
+  "importConfirmButton": {
+    "message": "覆盖并保存设置"
   },
   "googleSheets": {
     "message": "Google表格"

--- a/public/popup.html
+++ b/public/popup.html
@@ -180,12 +180,34 @@
           placeholder="www\.example\.com"
         />
         <input type="text" id="emojiName-custom-5" placeholder="Emoji Name" />
+        <div class="import-export-separator"></div>
+        <div class="import-export">
+          <button id="importButton" data-i18n="import">
+            Import emoji names
+          </button>
+          <button id="exportButton" data-i18n="export">
+            Export emoji names
+          </button>
+        </div>
+        <span id="exportMessage"></span>
+        <div id="importGroup" style="display: none">
+          <label for="importTextarea" data-i18n="importJsonLabel"
+            >Import other user's emoji names and custom regexes</label
+          >
+          <textarea
+            id="importTextarea"
+            placeholder="Input JSON......"
+          ></textarea>
+          <button id="importConfirmButton" data-i18n="importConfirmButton">
+            Overwrite and save settings
+          </button>
+        </div>
       </form>
     </div>
     <div class="main-container">
-      <hr />
+      <div class="separator"></div>
       <h1 data-i18n="linkFormatSettings">Google Sheets Range Link Format</h1>
-      <hr />
+      <div class="separator"></div>
       <form id="linkFormatForm" class="link-format-form">
         <label class="radio-label" for="linkFormat-html">
           <input
@@ -235,7 +257,7 @@
         </label>
       </form>
     </div>
-    <hr />
+    <div class="separator"></div>
     <footer class="footer">
       <a
         href="https://chromewebstore.google.com/detail/ohkebnhdjdgmfnhcmdpkdfddongdjadp?utm_source=popup"

--- a/public/popup.html
+++ b/public/popup.html
@@ -201,6 +201,12 @@
           <button id="importConfirmButton" data-i18n="importConfirmButton">
             Overwrite and save settings
           </button>
+          <div
+            id="importErrorMessage"
+            class="import-error-message"
+            style="display: none"
+            data-i18n="importFailure"
+          ></div>
         </div>
       </form>
     </div>

--- a/public/styles/popup.css
+++ b/public/styles/popup.css
@@ -133,6 +133,11 @@ textarea {
   margin-bottom: 8px;
 }
 
+.import-error-message {
+  color: #e71c1c;
+  margin-top: 6px;
+}
+
 .link-format-form {
   gap: 8px;
 }

--- a/public/styles/popup.css
+++ b/public/styles/popup.css
@@ -36,6 +36,7 @@ h1 {
 
 h2 {
   font-size: 1.2em;
+  margin: 12px 0;
 }
 
 form {
@@ -69,23 +70,67 @@ input[type="text"]:has(+ input) {
 
 button {
   width: 100%;
-  margin-top: 12px;
-  padding: 10px;
+  padding: 8px;
   font-size: 1em;
-  color: white;
-  background-color: #007bff;
-  border: none;
+  color: #007bff;
+  background-color: #fff;
+  border: 1px solid #ccc;
   border-radius: 4px;
   cursor: pointer;
 }
 
 button:hover {
-  background-color: #0056b3;
+  background-color: #e8eef6;
+}
+
+textarea {
+  -webkit-appearance: none;
+  appearance: none;
+  vertical-align: middle;
+  color: inherit;
+  font: inherit;
+  background: #fff;
+  padding: 10px;
+  margin: 0;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  text-align: inherit;
+  text-transform: inherit;
 }
 
 .emoji-form {
   height: 235px;
   overflow-y: scroll;
+}
+
+.separator {
+  margin: 0;
+  border-top: 1px solid #ccc;
+}
+
+.import-export-separator {
+  margin: 20px 0;
+  border-top: 1px solid #ccc;
+}
+
+.import-export {
+  display: flex;
+  flex-direction: row;
+  gap: 8px;
+  margin: 14px 0 40px;
+}
+
+#exportMessage {
+  margin: -30px 0 12px;
+}
+
+#importTextarea {
+  width: 100%;
+  height: 80px;
+  max-width: calc(100% - 22px);
+  max-height: 200px;
+  margin-top: 6px;
+  margin-bottom: 8px;
 }
 
 .link-format-form {
@@ -123,12 +168,6 @@ input[type="radio"] {
   padding: 1px 3px;
   border-radius: 2px;
   word-break: break-all;
-}
-
-hr {
-  margin: 0;
-  border: 0;
-  border-top: 1px solid #ccc;
 }
 
 a {

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -206,10 +206,13 @@ const handleImportConfirm = (importTextarea: HTMLTextAreaElement) => {
     return;
   }
 
+  const importErrorMessage = document.getElementById("importErrorMessage");
   try {
     importData(importedText);
+    if (importErrorMessage) {
+      importErrorMessage.style.display = "none";
+    }
   } catch {
-    const importErrorMessage = document.getElementById("importErrorMessage");
     if (importErrorMessage) {
       importErrorMessage.style.display = "block";
     }

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -16,6 +16,7 @@ import {
   buildEmojiNames,
   getInitialEmojiValues,
 } from "../shared/popup/emojiSettings";
+import { copyToClipboardShared } from "../shared/clipboard/copyToClipboardShared";
 
 type EmojiNamesStorageData = {
   emojiNames?: Partial<EmojiNameRecord>;
@@ -27,6 +28,11 @@ type CustomRegexesStorageData = {
 
 type LinkFormatStorageData = {
   [key: string]: unknown;
+};
+
+type ImportData = {
+  emojiNames?: Partial<EmojiNameRecord>;
+  customRegexes?: Partial<CustomRegexes>;
 };
 
 const updateLinkFormat = (format: LinkFormat) => {
@@ -80,9 +86,172 @@ const updateCustomRegexes = () => {
   });
 };
 
+// Export emoji names and custom regexes to clipboard
+const exportEmojiNames = async () => {
+  const data = await new Promise<{
+    emojiNames?: Partial<EmojiNameRecord>;
+    copylinkdevCustomRegexes?: Partial<CustomRegexes>;
+  }>((resolve) => {
+    chrome.storage.local.get(
+      ["emojiNames", "copylinkdevCustomRegexes"],
+      (result) => {
+        if (chrome.runtime.lastError) {
+          console.error(chrome.runtime.lastError);
+          resolve({});
+          return;
+        }
+        resolve(
+          result as {
+            emojiNames?: Partial<EmojiNameRecord>;
+            copylinkdevCustomRegexes?: Partial<CustomRegexes>;
+          },
+        );
+      },
+    );
+  });
+
+  const exportData = {
+    emojiNames: data.emojiNames ?? {},
+    customRegexes: data.copylinkdevCustomRegexes ?? {},
+  };
+
+  const json = JSON.stringify(exportData, null, 2);
+  await copyToClipboardShared(json);
+};
+
+const isImportData = (value: unknown): value is ImportData =>
+  typeof value === "object" &&
+  value !== null &&
+  ("emojiNames" in value || "customRegexes" in value);
+
+const isNonEmptyObject = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === "object" && Object.keys(value).length > 0;
+
+const saveImportedData = (data: ImportData) => {
+  if (isNonEmptyObject(data.emojiNames)) {
+    chrome.storage.local.set({ emojiNames: data.emojiNames }, () => {
+      if (chrome.runtime.lastError) {
+        console.error(chrome.runtime.lastError);
+      }
+    });
+  }
+
+  if (isNonEmptyObject(data.customRegexes)) {
+    chrome.storage.local.set(
+      { copylinkdevCustomRegexes: data.customRegexes },
+      () => {
+        if (chrome.runtime.lastError) {
+          console.error(chrome.runtime.lastError);
+        }
+      },
+    );
+  }
+};
+
+const refreshEmojiInputs = (emojiNames?: Partial<EmojiNameRecord>) => {
+  const emojiElements = getEmojiElements();
+  const values = getInitialEmojiValues(emojiNames);
+  for (const key of EMOJI_KEYS) {
+    const element = document.getElementById(emojiElements[key]);
+    if (element instanceof HTMLInputElement) {
+      element.value = values[key];
+    }
+  }
+};
+
+const refreshCustomRegexInputs = (
+  customRegexes?: Partial<CustomRegexes>,
+) => {
+  const customRegexElements = getCustomRegexElements();
+  for (const key of CUSTOM_REGEX_KEYS) {
+    const element = document.getElementById(customRegexElements[key]);
+    if (element instanceof HTMLInputElement) {
+      element.value = customRegexes?.[key] ?? "";
+    }
+  }
+};
+
+const refreshImportedInputs = (data: ImportData) => {
+  if (isNonEmptyObject(data.emojiNames)) {
+    refreshEmojiInputs(data.emojiNames);
+  }
+  if (isNonEmptyObject(data.customRegexes)) {
+    refreshCustomRegexInputs(data.customRegexes);
+  }
+};
+
+const importData = (importedText: string) => {
+  const parsedData: unknown = JSON.parse(importedText);
+  if (!isImportData(parsedData)) {
+    throw new Error("Invalid import data format");
+  }
+
+  saveImportedData(parsedData);
+  refreshImportedInputs(parsedData);
+};
+
+const handleImportConfirm = (importTextarea: HTMLTextAreaElement) => {
+  const importedText = importTextarea.value.trim();
+  if (!importedText) {
+    return;
+  }
+
+  try {
+    importData(importedText);
+  } catch (error) {
+    console.error("Error importing emoji names:", error);
+    alert(chrome.i18n.getMessage("importFailure"));
+  }
+};
+
 document.addEventListener("DOMContentLoaded", () => {
   // i18n
   const elements = document.querySelectorAll("[data-i18n]");
+
+  // Export button handler
+  const exportButton = document.getElementById("exportButton");
+  const exportMessage = document.getElementById("exportMessage");
+  if (exportButton && exportMessage) {
+    exportButton.addEventListener("click", (event) => {
+      event.preventDefault();
+      void exportEmojiNames()
+        .then(() => {
+          exportMessage.textContent = chrome.i18n.getMessage("exportSuccess");
+          setTimeout(() => {
+            exportMessage.textContent = "";
+          }, 8000);
+        })
+        .catch((error) => {
+          console.error("Error exporting emoji names:", error);
+          exportMessage.textContent = chrome.i18n.getMessage("exportFailure");
+        });
+    });
+  }
+
+  // Import button handler - show import UI
+  const importButton = document.getElementById("importButton");
+
+  if (importButton) {
+    importButton.addEventListener("click", (event) => {
+      event.preventDefault();
+      const importGroup = document.getElementById("importGroup");
+      if (importGroup) {
+        importGroup.style.display = "inline-block";
+      }
+    });
+  }
+
+  // Import button handler - process import
+  const importConfirmButton = document.getElementById("importConfirmButton");
+  const importTextarea = document.getElementById("importTextarea");
+
+  if (importConfirmButton && importTextarea instanceof HTMLTextAreaElement) {
+    importConfirmButton.addEventListener("click", (event) => {
+      event.preventDefault();
+      handleImportConfirm(importTextarea);
+    });
+  }
+
   elements.forEach((el) => {
     const messageKey = el.getAttribute("data-i18n");
     el.textContent =
@@ -95,12 +264,11 @@ document.addEventListener("DOMContentLoaded", () => {
       console.error(chrome.runtime.lastError);
       return;
     }
+    refreshEmojiInputs(data.emojiNames);
     const emojiElements = getEmojiElements();
-    const values = getInitialEmojiValues(data.emojiNames);
     for (const key of EMOJI_KEYS) {
       const element = document.getElementById(emojiElements[key]);
       if (element instanceof HTMLInputElement) {
-        element.value = values[key];
         element.addEventListener("input", updateEmojiNames);
       }
     }
@@ -113,12 +281,11 @@ document.addEventListener("DOMContentLoaded", () => {
         console.error(chrome.runtime.lastError);
         return;
       }
+      refreshCustomRegexInputs(data.copylinkdevCustomRegexes);
       const customRegexElements = getCustomRegexElements();
       for (const key of CUSTOM_REGEX_KEYS) {
         const element = document.getElementById(customRegexElements[key]);
         if (element instanceof HTMLInputElement) {
-          element.value = data.copylinkdevCustomRegexes?.[key] ?? "";
-
           element.addEventListener("input", updateCustomRegexes);
         }
       }

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -97,8 +97,7 @@ const exportEmojiNames = async () => {
       (result) => {
         if (chrome.runtime.lastError) {
           console.error(chrome.runtime.lastError);
-          resolve({});
-          return;
+          throw new Error("Failed to retrieve data from storage");
         }
         resolve(
           result as {

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -116,7 +116,8 @@ const exportEmojiNames = async () => {
   };
 
   const json = JSON.stringify(exportData, null, 2);
-  await copyToClipboardShared(json);
+  const result = await copyToClipboardShared(json);
+  return result;
 };
 
 const isImportData = (value: unknown): value is ImportData =>
@@ -159,9 +160,7 @@ const refreshEmojiInputs = (emojiNames?: Partial<EmojiNameRecord>) => {
   }
 };
 
-const refreshCustomRegexInputs = (
-  customRegexes?: Partial<CustomRegexes>,
-) => {
+const refreshCustomRegexInputs = (customRegexes?: Partial<CustomRegexes>) => {
   const customRegexElements = getCustomRegexElements();
   for (const key of CUSTOM_REGEX_KEYS) {
     const element = document.getElementById(customRegexElements[key]);
@@ -214,8 +213,13 @@ document.addEventListener("DOMContentLoaded", () => {
   if (exportButton && exportMessage) {
     exportButton.addEventListener("click", (event) => {
       event.preventDefault();
-      void exportEmojiNames()
-        .then(() => {
+      exportEmojiNames()
+        .then((result) => {
+          if (result.success === false) {
+            console.error("Error exporting emoji names:", result.error);
+            exportMessage.textContent = chrome.i18n.getMessage("exportFailure");
+            return;
+          }
           exportMessage.textContent = chrome.i18n.getMessage("exportSuccess");
           setTimeout(() => {
             exportMessage.textContent = "";

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -125,6 +125,17 @@ const isImportData = (value: unknown): value is ImportData =>
   value !== null &&
   ("emojiNames" in value || "customRegexes" in value);
 
+const formatImportedData = (data: ImportData): ImportData => {
+  const formattedData: ImportData = {};
+  if (data.emojiNames) {
+    formattedData.emojiNames = buildEmojiNames(data.emojiNames);
+  }
+  if (data.customRegexes) {
+    formattedData.customRegexes = buildCustomRegexes(data.customRegexes);
+  }
+  return formattedData;
+};
+
 const saveImportedData = (data: ImportData) => {
   if (data.emojiNames) {
     // allow empty object to clear emoji names
@@ -179,13 +190,14 @@ const refreshImportedInputs = (data: ImportData) => {
 };
 
 const importData = (importedText: string) => {
-  const parsedData: unknown = JSON.parse(importedText);
+  const parsedData = JSON.parse(importedText);
   if (!isImportData(parsedData)) {
     throw new Error("Invalid import data format");
   }
 
-  saveImportedData(parsedData);
-  refreshImportedInputs(parsedData);
+  const formattedData = formatImportedData(parsedData);
+  saveImportedData(formattedData);
+  refreshImportedInputs(formattedData);
 };
 
 const handleImportConfirm = (importTextarea: HTMLTextAreaElement) => {
@@ -196,9 +208,11 @@ const handleImportConfirm = (importTextarea: HTMLTextAreaElement) => {
 
   try {
     importData(importedText);
-  } catch (error) {
-    console.error("Error importing emoji names:", error);
-    alert(chrome.i18n.getMessage("importFailure"));
+  } catch {
+    const importErrorMessage = document.getElementById("importErrorMessage");
+    if (importErrorMessage) {
+      importErrorMessage.style.display = "block";
+    }
   }
 };
 

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -125,11 +125,9 @@ const isImportData = (value: unknown): value is ImportData =>
   value !== null &&
   ("emojiNames" in value || "customRegexes" in value);
 
-const isNonEmptyObject = (value: unknown): value is Record<string, unknown> =>
-  value !== null && typeof value === "object" && Object.keys(value).length > 0;
-
 const saveImportedData = (data: ImportData) => {
-  if (isNonEmptyObject(data.emojiNames)) {
+  if (data.emojiNames) {
+    // allow empty object to clear emoji names
     chrome.storage.local.set({ emojiNames: data.emojiNames }, () => {
       if (chrome.runtime.lastError) {
         console.error(chrome.runtime.lastError);
@@ -137,7 +135,8 @@ const saveImportedData = (data: ImportData) => {
     });
   }
 
-  if (isNonEmptyObject(data.customRegexes)) {
+  if (data.customRegexes) {
+    // allow empty object to clear custom regexes
     chrome.storage.local.set(
       { copylinkdevCustomRegexes: data.customRegexes },
       () => {
@@ -171,10 +170,10 @@ const refreshCustomRegexInputs = (customRegexes?: Partial<CustomRegexes>) => {
 };
 
 const refreshImportedInputs = (data: ImportData) => {
-  if (isNonEmptyObject(data.emojiNames)) {
+  if (data.emojiNames) {
     refreshEmojiInputs(data.emojiNames);
   }
-  if (isNonEmptyObject(data.customRegexes)) {
+  if (data.customRegexes) {
     refreshCustomRegexInputs(data.customRegexes);
   }
 };

--- a/src/shared/popup/emojiSettings.ts
+++ b/src/shared/popup/emojiSettings.ts
@@ -63,26 +63,25 @@ export const buildCustomRegexes = (
 
 export const getInitialEmojiValues = (
   stored?: Partial<EmojiNameRecord>,
-  defaults: EmojiNameRecord = DEFAULT_EMOJI_NAMES,
 ): EmojiNameRecord => {
+  const defaults = DEFAULT_EMOJI_NAMES;
   const result = { ...defaults };
+  if (!stored) {
+    return result;
+  }
 
-  const storedGithubPullRequest = stored?.githubPullRequest;
   const githubPullRequestFallback =
-    storedGithubPullRequest !== undefined && storedGithubPullRequest.length > 0
-      ? normalizeEmojiValue(storedGithubPullRequest, defaults.githubPullRequest)
-      : defaults.githubPullRequest;
+    stored.githubPullRequest ?? defaults.githubPullRequest;
   for (const key of fallbackEmojiKeys) {
     result[key] = githubPullRequestFallback;
   }
 
-  if (stored) {
-    for (const key of EMOJI_KEYS) {
-      const value = stored[key];
-      if (value !== undefined && value.length > 0) {
-        result[key] = normalizeEmojiValue(value, defaults[key]);
-      }
+  for (const key of EMOJI_KEYS) {
+    const value = stored[key];
+    if (value !== undefined) {
+      result[key] = normalizeEmojiValue(value, defaults[key]);
     }
   }
+
   return result;
 };

--- a/src/shared/popup/emojiSettings.ts
+++ b/src/shared/popup/emojiSettings.ts
@@ -55,6 +55,8 @@ export const buildCustomRegexes = (
   for (const key of CUSTOM_REGEX_KEYS) {
     const rawValue = values[key];
     if (typeof rawValue === "string") {
+      // verify that the regex is valid by attempting to create a RegExp object
+      new RegExp(rawValue);
       result[key] = rawValue;
     }
   }

--- a/tests/e2e/popup.spec.ts
+++ b/tests/e2e/popup.spec.ts
@@ -1,10 +1,15 @@
 import {
+  buildCustomRegexes,
+  buildEmojiNames,
+} from "../../src/shared/popup/emojiSettings";
+import {
   expect,
   readClipboardHtml,
   readClipboardText,
   test,
   triggerCommand,
 } from "./fixtures";
+import { DEFAULT_EMOJI_NAMES } from "../../src/shared/constants";
 
 test.describe("Popup settings page", () => {
   test("selecting a link format radio persists to storage", async ({
@@ -86,6 +91,22 @@ test.describe("Popup settings page", () => {
     extensionId,
     context,
   }) => {
+    const defaultCustomRegexes = {
+      customRegex1: "default\\.example\\.com",
+    };
+    await sw.evaluate(
+      async ({ emojiNames, customRegexes }) => {
+        await chrome.storage.local.set({
+          emojiNames,
+          copylinkdevCustomRegexes: customRegexes,
+        });
+      },
+      {
+        emojiNames: DEFAULT_EMOJI_NAMES,
+        customRegexes: defaultCustomRegexes,
+      },
+    );
+
     const importedSettings = {
       emojiNames: {
         github: ":imported_github:",
@@ -100,6 +121,13 @@ test.describe("Popup settings page", () => {
     await popupPage.goto(`chrome-extension://${extensionId}/popup.html`, {
       waitUntil: "domcontentloaded",
     });
+
+    await expect(popupPage.locator("#emojiName-github")).toHaveValue(
+      DEFAULT_EMOJI_NAMES.github,
+    );
+    await expect(popupPage.locator("#regex-custom-1")).toHaveValue(
+      defaultCustomRegexes.customRegex1,
+    );
 
     await popupPage.click("#importButton");
     await expect(popupPage.locator("#importGroup")).toBeVisible();
@@ -118,6 +146,12 @@ test.describe("Popup settings page", () => {
       importedSettings.customRegexes.customRegex1,
     );
 
+    // Import formatting fills in defaults for regular emoji names and omits
+    // GitHub PR status-specific fallback emoji names.
+    const expectedEmojiNames = buildEmojiNames(importedSettings.emojiNames);
+    const expectedCustomRegexes = buildCustomRegexes(
+      importedSettings.customRegexes,
+    );
     await expect
       .poll(async () => {
         return sw.evaluate(async () => {
@@ -130,8 +164,8 @@ test.describe("Popup settings page", () => {
         });
       })
       .toEqual({
-        emojiNames: importedSettings.emojiNames,
-        copylinkdevCustomRegexes: importedSettings.customRegexes,
+        emojiNames: expectedEmojiNames,
+        copylinkdevCustomRegexes: expectedCustomRegexes,
       });
   });
 

--- a/tests/e2e/popup.spec.ts
+++ b/tests/e2e/popup.spec.ts
@@ -54,12 +54,15 @@ test.describe("Popup settings page", () => {
     const customRegexes = {
       customRegex1: "export\\.example\\.com",
     };
-    await sw.evaluate(async ({ emojiNames, customRegexes }) => {
-      await chrome.storage.local.set({
-        emojiNames,
-        copylinkdevCustomRegexes: customRegexes,
-      });
-    }, { emojiNames, customRegexes });
+    await sw.evaluate(
+      async ({ emojiNames, customRegexes }) => {
+        await chrome.storage.local.set({
+          emojiNames,
+          copylinkdevCustomRegexes: customRegexes,
+        });
+      },
+      { emojiNames, customRegexes },
+    );
 
     const popupPage = await context.newPage();
     await popupPage.goto(`chrome-extension://${extensionId}/popup.html`, {
@@ -97,9 +100,9 @@ test.describe("Popup settings page", () => {
 
     await popupPage.click("#importButton");
     await expect(popupPage.locator("#importGroup")).toBeVisible();
-    await popupPage.locator("#importTextarea").fill(
-      JSON.stringify(importedSettings),
-    );
+    await popupPage
+      .locator("#importTextarea")
+      .fill(JSON.stringify(importedSettings));
     await popupPage.click("#importConfirmButton");
 
     await expect(popupPage.locator("#emojiName-github")).toHaveValue(

--- a/tests/e2e/popup.spec.ts
+++ b/tests/e2e/popup.spec.ts
@@ -70,8 +70,11 @@ test.describe("Popup settings page", () => {
     });
 
     await popupPage.click("#exportButton");
+    const exportSuccessMessage = await popupPage.evaluate(() =>
+      chrome.i18n.getMessage("exportSuccess"),
+    );
     await expect(popupPage.locator("#exportMessage")).toHaveText(
-      "Emoji names and custom regexes exported to clipboard",
+      exportSuccessMessage,
     );
 
     const exported = JSON.parse(await readClipboardText(popupPage));

--- a/tests/e2e/popup.spec.ts
+++ b/tests/e2e/popup.spec.ts
@@ -1,4 +1,10 @@
-import { expect, readClipboardHtml, test, triggerCommand } from "./fixtures";
+import {
+  expect,
+  readClipboardHtml,
+  readClipboardText,
+  test,
+  triggerCommand,
+} from "./fixtures";
 
 test.describe("Popup settings page", () => {
   test("selecting a link format radio persists to storage", async ({
@@ -34,6 +40,93 @@ test.describe("Popup settings page", () => {
       });
     });
     expect(stored2).toBe("plainUrl");
+  });
+
+  test("exports emoji names and custom regexes to the clipboard", async ({
+    sw,
+    extensionId,
+    context,
+  }) => {
+    const emojiNames = {
+      github: ":exported_github:",
+      customWebsite1: ":exported_custom:",
+    };
+    const customRegexes = {
+      customRegex1: "export\\.example\\.com",
+    };
+    await sw.evaluate(async ({ emojiNames, customRegexes }) => {
+      await chrome.storage.local.set({
+        emojiNames,
+        copylinkdevCustomRegexes: customRegexes,
+      });
+    }, { emojiNames, customRegexes });
+
+    const popupPage = await context.newPage();
+    await popupPage.goto(`chrome-extension://${extensionId}/popup.html`, {
+      waitUntil: "domcontentloaded",
+    });
+
+    await popupPage.click("#exportButton");
+    await expect(popupPage.locator("#exportMessage")).toHaveText(
+      "Emoji names and custom regexes exported to clipboard",
+    );
+
+    const exported = JSON.parse(await readClipboardText(popupPage));
+    expect(exported).toEqual({ emojiNames, customRegexes });
+  });
+
+  test("imports settings, saves them, and refreshes the form inputs", async ({
+    sw,
+    extensionId,
+    context,
+  }) => {
+    const importedSettings = {
+      emojiNames: {
+        github: ":imported_github:",
+        customWebsite1: ":imported_custom:",
+      },
+      customRegexes: {
+        customRegex1: "import\\.example\\.com",
+      },
+    };
+
+    const popupPage = await context.newPage();
+    await popupPage.goto(`chrome-extension://${extensionId}/popup.html`, {
+      waitUntil: "domcontentloaded",
+    });
+
+    await popupPage.click("#importButton");
+    await expect(popupPage.locator("#importGroup")).toBeVisible();
+    await popupPage.locator("#importTextarea").fill(
+      JSON.stringify(importedSettings),
+    );
+    await popupPage.click("#importConfirmButton");
+
+    await expect(popupPage.locator("#emojiName-github")).toHaveValue(
+      importedSettings.emojiNames.github,
+    );
+    await expect(popupPage.locator("#emojiName-custom-1")).toHaveValue(
+      importedSettings.emojiNames.customWebsite1,
+    );
+    await expect(popupPage.locator("#regex-custom-1")).toHaveValue(
+      importedSettings.customRegexes.customRegex1,
+    );
+
+    await expect
+      .poll(async () => {
+        return sw.evaluate(async () => {
+          return new Promise((resolve) => {
+            chrome.storage.local.get(
+              ["emojiNames", "copylinkdevCustomRegexes"],
+              (data) => resolve(data),
+            );
+          });
+        });
+      })
+      .toEqual({
+        emojiNames: importedSettings.emojiNames,
+        copylinkdevCustomRegexes: importedSettings.customRegexes,
+      });
   });
 
   test("changing an emoji name persists and is used in copy", async ({

--- a/tests/unit/emojiSettings.test.ts
+++ b/tests/unit/emojiSettings.test.ts
@@ -1,4 +1,5 @@
 import {
+  buildCustomRegexes,
   buildEmojiNames,
   getInitialEmojiValues,
 } from "../../src/shared/popup/emojiSettings";
@@ -42,5 +43,27 @@ describe("emojiSettings – GitHub PR status fallback", () => {
 
     expect(values.githubMergedPullRequest).toBe(":merged_pull_request:");
     expect(values.githubDraftPullRequest).toBe(":pull_request:");
+  });
+});
+
+describe("buildCustomRegexes", () => {
+  it("preserves valid custom regex values", () => {
+    expect(
+      buildCustomRegexes({
+        customRegex1: "example\\.com/(foo|bar)",
+        customRegex2: "",
+      }),
+    ).toEqual({
+      customRegex1: "example\\.com/(foo|bar)",
+      customRegex2: "",
+    });
+  });
+
+  it("throws when a custom regex is invalid", () => {
+    expect(() =>
+      buildCustomRegexes({
+        customRegex1: "[",
+      }),
+    ).toThrow();
   });
 });


### PR DESCRIPTION
resolves #39 

- Add functionalities for exporting and importing emoji names and custom regexes
  - Add export button in `popup.html` to share your settings
  - Add import button and a textarea for importing other user's settings
  - Support importing `{ emojiNames: {}, customRegexes: {} }` to reset settings to default
- Add E2E tests
- Add validation for custom regexes in `buildCustomRegexes` and corresponding unit tests
- Replace `<hr>` with `<div>` for improved accessibility
- Add `.pnpm-store/` to `.gitignore`
- Change PR emoji name labels (e.g., GitHub Draft Pull Request → GitHub Pull Request (Draft))