### PR TITLE
Enhance test clarity with comments and update e2e test URLs

### DIFF
--- a/tests/e2e/core-commands.spec.ts
+++ b/tests/e2e/core-commands.spec.ts
@@ -18,10 +18,14 @@ test.describe("Core commands on example.com", () => {
     sw,
     context,
   }) => {
+    // Given: The default link format is configured and example.com is open.
     const page = await context.newPage();
     await page.goto("https://example.com", { waitUntil: "domcontentloaded" });
+
+    // When: The copy-link command is executed.
     await triggerCommand(sw, page, "copy-link");
 
+    // Then: The clipboard contains the page title as text and an HTML anchor.
     const text = await readClipboardText(page);
     expect(text).toBe("Example Domain");
 
@@ -36,10 +40,14 @@ test.describe("Core commands on example.com", () => {
     sw,
     context,
   }) => {
+    // Given: The default link format is configured and example.com is open.
     const page = await context.newPage();
     await page.goto("https://example.com", { waitUntil: "domcontentloaded" });
+
+    // When: The copy-title command is executed.
     await triggerCommand(sw, page, "copy-title");
 
+    // Then: The clipboard contains only the page title as plain text.
     const text = await readClipboardText(page);
     expect(text).toBe("Example Domain");
   });
@@ -48,10 +56,14 @@ test.describe("Core commands on example.com", () => {
     sw,
     context,
   }) => {
+    // Given: The default link format is configured and example.com is open.
     const page = await context.newPage();
     await page.goto("https://example.com", { waitUntil: "domcontentloaded" });
+
+    // When: The copy-link-for-slack command is executed.
     await triggerCommand(sw, page, "copy-link-for-slack");
 
+    // Then: The clipboard contains a Markdown link as text and an HTML anchor.
     const text = await readClipboardText(page);
     // Default format is htmlWithEmoji → plain text is markdown
     expect(text).toBe("[Example Domain](https://example.com/)");

--- a/tests/e2e/core-commands.spec.ts
+++ b/tests/e2e/core-commands.spec.ts
@@ -1,4 +1,5 @@
 import {
+  E2E_FIXTURE_URL,
   expect,
   readClipboardHtml,
   readClipboardText,
@@ -6,7 +7,7 @@ import {
   triggerCommand,
 } from "./fixtures";
 
-test.describe("Core commands on example.com", () => {
+test.describe("Core commands on the e2e fixture page", () => {
   test.beforeEach(async ({ sw }) => {
     // Reset link format to default (htmlWithEmoji) before each test
     await sw.evaluate(async () => {
@@ -18,21 +19,23 @@ test.describe("Core commands on example.com", () => {
     sw,
     context,
   }) => {
-    // Given: The default link format is configured and example.com is open.
+    // Given: The default link format is configured and the e2e fixture page is open.
     const page = await context.newPage();
-    await page.goto("https://example.com", { waitUntil: "domcontentloaded" });
+    await page.goto(E2E_FIXTURE_URL, { waitUntil: "domcontentloaded" });
+    const fixtureTitle = await page.title();
+    const fixtureUrl = page.url();
 
     // When: The copy-link command is executed.
     await triggerCommand(sw, page, "copy-link");
 
     // Then: The clipboard contains the page title as text and an HTML anchor.
     const text = await readClipboardText(page);
-    expect(text).toBe("Example Domain");
+    expect(text).toBe(fixtureTitle);
 
     const html = await readClipboardHtml(page);
     expect(html).not.toBeNull();
-    expect(html).toContain("Example Domain");
-    expect(html).toContain('href="https://example.com/"');
+    expect(html).toContain(fixtureTitle);
+    expect(html).toContain(`href="${fixtureUrl}"`);
     expect(html).toContain("</a>");
   });
 
@@ -40,25 +43,28 @@ test.describe("Core commands on example.com", () => {
     sw,
     context,
   }) => {
-    // Given: The default link format is configured and example.com is open.
+    // Given: The default link format is configured and the e2e fixture page is open.
     const page = await context.newPage();
-    await page.goto("https://example.com", { waitUntil: "domcontentloaded" });
+    await page.goto(E2E_FIXTURE_URL, { waitUntil: "domcontentloaded" });
+    const fixtureTitle = await page.title();
 
     // When: The copy-title command is executed.
     await triggerCommand(sw, page, "copy-title");
 
     // Then: The clipboard contains only the page title as plain text.
     const text = await readClipboardText(page);
-    expect(text).toBe("Example Domain");
+    expect(text).toBe(fixtureTitle);
   });
 
   test("copy-link-for-slack copies markdown text and HTML with emoji", async ({
     sw,
     context,
   }) => {
-    // Given: The default link format is configured and example.com is open.
+    // Given: The default link format is configured and the e2e fixture page is open.
     const page = await context.newPage();
-    await page.goto("https://example.com", { waitUntil: "domcontentloaded" });
+    await page.goto(E2E_FIXTURE_URL, { waitUntil: "domcontentloaded" });
+    const fixtureTitle = await page.title();
+    const fixtureUrl = page.url();
 
     // When: The copy-link-for-slack command is executed.
     await triggerCommand(sw, page, "copy-link-for-slack");
@@ -66,12 +72,12 @@ test.describe("Core commands on example.com", () => {
     // Then: The clipboard contains a Markdown link as text and an HTML anchor.
     const text = await readClipboardText(page);
     // Default format is htmlWithEmoji → plain text is markdown
-    expect(text).toBe("[Example Domain](https://example.com/)");
+    expect(text).toBe(`[${fixtureTitle}](${fixtureUrl})`);
 
     const html = await readClipboardHtml(page);
     expect(html).not.toBeNull();
-    expect(html).toContain("Example Domain");
+    expect(html).toContain(fixtureTitle);
     expect(html).toContain("</a>");
-    // example.com is not a recognized site, so no emoji prefix
+    // The e2e fixture page is not a recognized site, so no emoji prefix is added.
   });
 });

--- a/tests/e2e/fixtures.ts
+++ b/tests/e2e/fixtures.ts
@@ -68,6 +68,9 @@ export const test = base.extend<{
 
 export const expect = test.expect;
 
+/** Static page used as the generic non-site-specific fixture in e2e tests. */
+export const E2E_FIXTURE_URL = "https://wintorse.github.io/e2e-fixture.html";
+
 /** Public Google Sheets spreadsheet used across e2e tests. */
 export const SHEETS_URL =
   "https://docs.google.com/spreadsheets/d/1edX-93flOBU51Vd-3dh0oZ5FDFdbpuV1V6uX3gLSADE/edit";

--- a/tests/e2e/google-sheets.spec.ts
+++ b/tests/e2e/google-sheets.spec.ts
@@ -11,6 +11,7 @@ test.describe("Google Sheets range link", () => {
     sw,
     context,
   }) => {
+    // Given: A Google Sheets page is open with range C2:E4 selected.
     const page = await context.newPage();
     await page.goto(SHEETS_URL_WITH_RANGE, {
       waitUntil: "load",
@@ -25,8 +26,10 @@ test.describe("Google Sheets range link", () => {
       { timeout: 15_000 },
     );
 
+    // When: The copy-google-sheets-range command is executed.
     await triggerCommand(sw, page, "copy-google-sheets-range");
 
+    // Then: The clipboard URL contains the spreadsheet, selected range, and sheet ID.
     const text = await readClipboardText(page);
     // The clipboard should contain a URL with the pre-selected range
     expect(text).toContain("docs.google.com/spreadsheets");
@@ -38,13 +41,17 @@ test.describe("Google Sheets range link", () => {
     sw,
     context,
   }) => {
+    // Given: An example.com page is open and the clipboard contains a sentinel value.
     const page = await context.newPage();
     await page.goto("https://example.com", { waitUntil: "domcontentloaded" });
 
     // Write a known value to the clipboard first
     await page.evaluate(() => navigator.clipboard.writeText("__sentinel__"));
+
+    // When: The copy-google-sheets-range command is executed.
     await triggerCommand(sw, page, "copy-google-sheets-range");
 
+    // Then: The sentinel value remains unchanged because the page is not Google Sheets.
     const text = await readClipboardText(page);
     // Should remain unchanged since the command is a no-op on non-Sheets pages
     expect(text).toBe("__sentinel__");

--- a/tests/e2e/google-sheets.spec.ts
+++ b/tests/e2e/google-sheets.spec.ts
@@ -1,4 +1,5 @@
 import {
+  E2E_FIXTURE_URL,
   SHEETS_URL_WITH_RANGE,
   expect,
   readClipboardText,
@@ -41,9 +42,9 @@ test.describe("Google Sheets range link", () => {
     sw,
     context,
   }) => {
-    // Given: An example.com page is open and the clipboard contains a sentinel value.
+    // Given: The e2e fixture page is open and the clipboard contains a sentinel value.
     const page = await context.newPage();
-    await page.goto("https://example.com", { waitUntil: "domcontentloaded" });
+    await page.goto(E2E_FIXTURE_URL, { waitUntil: "domcontentloaded" });
 
     // Write a known value to the clipboard first
     await page.evaluate(() => navigator.clipboard.writeText("__sentinel__"));

--- a/tests/e2e/http-site.spec.ts
+++ b/tests/e2e/http-site.spec.ts
@@ -1,4 +1,5 @@
 import {
+  E2E_FIXTURE_URL,
   expect,
   gotoWithRetry,
   readClipboardHtml,
@@ -36,7 +37,7 @@ test.describe("HTTP site (navigator.clipboard unavailable)", () => {
     // Open an HTTPS page to read clipboard, since navigator.clipboard
     // is unavailable in the HTTP page context.
     const clipboardPage = await context.newPage();
-    await clipboardPage.goto("https://example.com", {
+    await clipboardPage.goto(E2E_FIXTURE_URL, {
       waitUntil: "domcontentloaded",
     });
 
@@ -63,7 +64,7 @@ test.describe("HTTP site (navigator.clipboard unavailable)", () => {
     });
 
     const clipboardPage = await context.newPage();
-    await clipboardPage.goto("https://example.com", {
+    await clipboardPage.goto(E2E_FIXTURE_URL, {
       waitUntil: "domcontentloaded",
     });
 
@@ -87,7 +88,7 @@ test.describe("HTTP site (navigator.clipboard unavailable)", () => {
     });
 
     const clipboardPage = await context.newPage();
-    await clipboardPage.goto("https://example.com", {
+    await clipboardPage.goto(E2E_FIXTURE_URL, {
       waitUntil: "domcontentloaded",
     });
 

--- a/tests/e2e/http-site.spec.ts
+++ b/tests/e2e/http-site.spec.ts
@@ -26,6 +26,7 @@ test.describe("HTTP site (navigator.clipboard unavailable)", () => {
     sw,
     context,
   }) => {
+    // Given: An HTTP page and an HTTPS page for reading the clipboard are open.
     const httpPage = await context.newPage();
     await gotoWithRetry(httpPage, HTTP_URL, {
       waitUntil: "domcontentloaded",
@@ -39,8 +40,10 @@ test.describe("HTTP site (navigator.clipboard unavailable)", () => {
       waitUntil: "domcontentloaded",
     });
 
+    // When: The copy-link command is executed on the HTTP page.
     await triggerCommand(sw, httpPage, "copy-link");
 
+    // Then: The HTTPS page can read the title as text and an HTML anchor.
     const text = await readClipboardText(clipboardPage);
     expect(text).toBe(HTTP_TITLE);
 
@@ -52,6 +55,7 @@ test.describe("HTTP site (navigator.clipboard unavailable)", () => {
   });
 
   test("copy-title copies plain text title", async ({ sw, context }) => {
+    // Given: An HTTP page and an HTTPS page for reading the clipboard are open.
     const httpPage = await context.newPage();
     await gotoWithRetry(httpPage, HTTP_URL, {
       waitUntil: "domcontentloaded",
@@ -63,8 +67,10 @@ test.describe("HTTP site (navigator.clipboard unavailable)", () => {
       waitUntil: "domcontentloaded",
     });
 
+    // When: The copy-title command is executed on the HTTP page.
     await triggerCommand(sw, httpPage, "copy-title");
 
+    // Then: The HTTPS page reads only the HTTP page title as plain text.
     const text = await readClipboardText(clipboardPage);
     expect(text).toBe(HTTP_TITLE);
   });
@@ -73,6 +79,7 @@ test.describe("HTTP site (navigator.clipboard unavailable)", () => {
     sw,
     context,
   }) => {
+    // Given: An HTTP page and an HTTPS page for reading the clipboard are open.
     const httpPage = await context.newPage();
     await gotoWithRetry(httpPage, HTTP_URL, {
       waitUntil: "domcontentloaded",
@@ -84,8 +91,10 @@ test.describe("HTTP site (navigator.clipboard unavailable)", () => {
       waitUntil: "domcontentloaded",
     });
 
+    // When: The copy-link-for-slack command is executed on the HTTP page.
     await triggerCommand(sw, httpPage, "copy-link-for-slack");
 
+    // Then: The HTTPS page reads a Markdown link as text and an HTML anchor.
     const text = await readClipboardText(clipboardPage);
     // www.kmoni.bosai.go.jp is not a recognized site, so no emoji prefix
     expect(text).toContain(`[${HTTP_TITLE}]`);

--- a/tests/e2e/link-formats.spec.ts
+++ b/tests/e2e/link-formats.spec.ts
@@ -19,6 +19,7 @@ test.describe("Link format settings for copy-google-sheets-range", () => {
     sw,
     context,
   }) => {
+    // Given: The html link format is selected and a Google Sheets range is open.
     await setLinkFormat(sw, "html");
     const page = await context.newPage();
     await page.goto(SHEETS_URL_WITH_RANGE, {
@@ -33,8 +34,11 @@ test.describe("Link format settings for copy-google-sheets-range", () => {
           .length > 0,
       { timeout: 15_000 },
     );
+
+    // When: The copy-google-sheets-range command is executed.
     await triggerCommand(sw, page, "copy-google-sheets-range");
 
+    // Then: The clipboard has the title as text and an HTML anchor without an emoji.
     const text = await readClipboardText(page);
     // text should be the formatted title (Google Docs title getter)
     expect(text).toContain("テスト spreadsheet");
@@ -50,6 +54,7 @@ test.describe("Link format settings for copy-google-sheets-range", () => {
     sw,
     context,
   }) => {
+    // Given: The htmlWithEmoji link format is selected and a Google Sheets range is open.
     await setLinkFormat(sw, "htmlWithEmoji");
     const page = await context.newPage();
     await page.goto(SHEETS_URL_WITH_RANGE, {
@@ -62,8 +67,11 @@ test.describe("Link format settings for copy-google-sheets-range", () => {
           .length > 0,
       { timeout: 15_000 },
     );
+
+    // When: The copy-google-sheets-range command is executed.
     await triggerCommand(sw, page, "copy-google-sheets-range");
 
+    // Then: The clipboard has a Markdown link as text and an emoji plus anchor as HTML.
     const text = await readClipboardText(page);
     // htmlWithEmoji → plain text is markdown format
     expect(text).toContain("[テスト spreadsheet]");
@@ -79,6 +87,7 @@ test.describe("Link format settings for copy-google-sheets-range", () => {
     sw,
     context,
   }) => {
+    // Given: The markdown link format is selected and a Google Sheets range is open.
     await setLinkFormat(sw, "markdown");
     const page = await context.newPage();
     await page.goto(SHEETS_URL_WITH_RANGE, {
@@ -91,14 +100,18 @@ test.describe("Link format settings for copy-google-sheets-range", () => {
           .length > 0,
       { timeout: 15_000 },
     );
+
+    // When: The copy-google-sheets-range command is executed.
     await triggerCommand(sw, page, "copy-google-sheets-range");
 
+    // Then: The clipboard text is a Markdown link containing the selected range.
     const text = await readClipboardText(page);
     expect(text).toContain("[テスト spreadsheet]");
     expect(text).toContain("range=C2:E4");
   });
 
   test("plainUrl format: text is URL only", async ({ sw, context }) => {
+    // Given: The plainUrl link format is selected and a Google Sheets range is open.
     await setLinkFormat(sw, "plainUrl");
     const page = await context.newPage();
     await page.goto(SHEETS_URL_WITH_RANGE, {
@@ -111,8 +124,11 @@ test.describe("Link format settings for copy-google-sheets-range", () => {
           .length > 0,
       { timeout: 15_000 },
     );
+
+    // When: The copy-google-sheets-range command is executed.
     await triggerCommand(sw, page, "copy-google-sheets-range");
 
+    // Then: The clipboard contains only the URL with the selected range.
     const text = await readClipboardText(page);
     expect(text).toContain("docs.google.com/spreadsheets");
     expect(text).toContain("range=C2:E4");

--- a/tests/e2e/popup.spec.ts
+++ b/tests/e2e/popup.spec.ts
@@ -1,14 +1,15 @@
 import {
-  buildCustomRegexes,
-  buildEmojiNames,
-} from "../../src/shared/popup/emojiSettings";
-import {
+  E2E_FIXTURE_URL,
   expect,
   readClipboardHtml,
   readClipboardText,
   test,
   triggerCommand,
 } from "./fixtures";
+import {
+  buildCustomRegexes,
+  buildEmojiNames,
+} from "../../src/shared/popup/emojiSettings";
 import { DEFAULT_EMOJI_NAMES } from "../../src/shared/constants";
 
 test.describe("Popup settings page", () => {
@@ -243,7 +244,7 @@ test.describe("Popup settings page", () => {
 
     // When: A matching URL regex and custom emoji are entered.
     await regexInput.clear();
-    await regexInput.fill("example\\.com");
+    await regexInput.fill("wintorse\\.github\\.io");
 
     const emojiInput = popupPage.locator("#emojiName-custom-1");
     await emojiInput.clear();
@@ -252,9 +253,9 @@ test.describe("Popup settings page", () => {
     // Wait for input events
     await popupPage.waitForTimeout(300);
 
-    // When: copy-link-for-slack is executed on a matching example.com page.
+    // When: copy-link-for-slack is executed on a matching e2e fixture page.
     const page = await context.newPage();
-    await page.goto("https://example.com", {
+    await page.goto(E2E_FIXTURE_URL, {
       waitUntil: "domcontentloaded",
     });
     await triggerCommand(sw, page, "copy-link-for-slack");

--- a/tests/e2e/popup.spec.ts
+++ b/tests/e2e/popup.spec.ts
@@ -17,15 +17,16 @@ test.describe("Popup settings page", () => {
     extensionId,
     context,
   }) => {
+    // Given: The popup settings page is open with the link format controls visible.
     const page = await context.newPage();
     await page.goto(`chrome-extension://${extensionId}/popup.html`, {
       waitUntil: "domcontentloaded",
     });
 
-    // Click the markdown radio
+    // When: The markdown radio is selected.
     await page.click("#linkFormat-markdown");
 
-    // Verify storage was updated
+    // Then: The markdown format is persisted to extension storage.
     const stored = await sw.evaluate(async () => {
       return new Promise((resolve) => {
         chrome.storage.local.get("copylinkdevLinkFormat", (data) => {
@@ -35,7 +36,7 @@ test.describe("Popup settings page", () => {
     });
     expect(stored).toBe("markdown");
 
-    // Click the plainUrl radio
+    // When: The plainUrl radio is selected.
     await page.click("#linkFormat-plainUrl");
     const stored2 = await sw.evaluate(async () => {
       return new Promise((resolve) => {
@@ -44,6 +45,7 @@ test.describe("Popup settings page", () => {
         });
       });
     });
+    // Then: The plainUrl format is persisted to extension storage.
     expect(stored2).toBe("plainUrl");
   });
 
@@ -52,6 +54,7 @@ test.describe("Popup settings page", () => {
     extensionId,
     context,
   }) => {
+    // Given: Custom emoji names and URL regexes are stored and the popup is open.
     const emojiNames = {
       github: ":exported_github:",
       customWebsite1: ":exported_custom:",
@@ -74,10 +77,13 @@ test.describe("Popup settings page", () => {
       waitUntil: "domcontentloaded",
     });
 
+    // When: The export button is clicked.
     await popupPage.click("#exportButton");
     const exportSuccessMessage = await popupPage.evaluate(() =>
       chrome.i18n.getMessage("exportSuccess"),
     );
+
+    // Then: A success message is shown and the settings are copied as JSON.
     await expect(popupPage.locator("#exportMessage")).toHaveText(
       exportSuccessMessage,
     );
@@ -91,6 +97,7 @@ test.describe("Popup settings page", () => {
     extensionId,
     context,
   }) => {
+    // Given: Default settings and a different settings payload to import are prepared.
     const defaultCustomRegexes = {
       customRegex1: "default\\.example\\.com",
     };
@@ -129,6 +136,7 @@ test.describe("Popup settings page", () => {
       defaultCustomRegexes.customRegex1,
     );
 
+    // When: The imported settings are entered and confirmed.
     await popupPage.click("#importButton");
     await expect(popupPage.locator("#importGroup")).toBeVisible();
     await popupPage
@@ -136,6 +144,7 @@ test.describe("Popup settings page", () => {
       .fill(JSON.stringify(importedSettings));
     await popupPage.click("#importConfirmButton");
 
+    // Then: The form inputs refresh with the imported values.
     await expect(popupPage.locator("#emojiName-github")).toHaveValue(
       importedSettings.emojiNames.github,
     );
@@ -146,6 +155,7 @@ test.describe("Popup settings page", () => {
       importedSettings.customRegexes.customRegex1,
     );
 
+    // Then: Storage contains normalized imported settings.
     // Import formatting fills in defaults for regular emoji names and omits
     // GitHub PR status-specific fallback emoji names.
     const expectedEmojiNames = buildEmojiNames(importedSettings.emojiNames);
@@ -174,20 +184,22 @@ test.describe("Popup settings page", () => {
     extensionId,
     context,
   }) => {
-    // Step 1: Change the GitHub emoji in popup settings
+    // Given: The popup settings page is open with the GitHub emoji input available.
     const popupPage = await context.newPage();
     await popupPage.goto(`chrome-extension://${extensionId}/popup.html`, {
       waitUntil: "domcontentloaded",
     });
 
     const githubInput = popupPage.locator("#emojiName-github");
+
+    // When: The GitHub emoji is changed to a custom value.
     await githubInput.clear();
     await githubInput.fill(":custom_github:");
 
     // Wait for the input event debounce
     await popupPage.waitForTimeout(300);
 
-    // Step 2: Verify storage reflects the change
+    // Then: The custom emoji is persisted to storage.
     const stored = await sw.evaluate(async () => {
       type StorageData = { emojiNames?: Record<string, string> };
       return new Promise<Record<string, string> | undefined>((resolve) => {
@@ -198,17 +210,19 @@ test.describe("Popup settings page", () => {
     });
     expect(stored).toHaveProperty("github", ":custom_github:");
 
-    // Step 3: Use copy-link-for-slack on a GitHub page to verify emoji is applied
+    // When: copy-link-for-slack is executed on a GitHub page.
     const page = await context.newPage();
     await page.goto("https://github.com/wintorse/copylink-dev", {
       waitUntil: "domcontentloaded",
     });
     await triggerCommand(sw, page, "copy-link-for-slack");
+
+    // Then: The copied HTML contains the custom GitHub emoji.
     const html = await readClipboardHtml(page);
     expect(html).not.toBeNull();
     expect(html).toContain(":custom_github:");
 
-    // Cleanup: reset emoji names
+    // Cleanup: Reset the test-specific emoji settings.
     await sw.evaluate(async () => {
       await chrome.storage.local.remove("emojiNames");
     });
@@ -219,13 +233,15 @@ test.describe("Popup settings page", () => {
     extensionId,
     context,
   }) => {
-    // Step 1: Register a custom website in popup settings
+    // Given: The popup settings page is open with an empty custom website entry.
     const popupPage = await context.newPage();
     await popupPage.goto(`chrome-extension://${extensionId}/popup.html`, {
       waitUntil: "domcontentloaded",
     });
 
     const regexInput = popupPage.locator("#regex-custom-1");
+
+    // When: A matching URL regex and custom emoji are entered.
     await regexInput.clear();
     await regexInput.fill("example\\.com");
 
@@ -236,18 +252,19 @@ test.describe("Popup settings page", () => {
     // Wait for input events
     await popupPage.waitForTimeout(300);
 
-    // Step 2: Visit example.com and copy-link-for-slack
+    // When: copy-link-for-slack is executed on a matching example.com page.
     const page = await context.newPage();
     await page.goto("https://example.com", {
       waitUntil: "domcontentloaded",
     });
     await triggerCommand(sw, page, "copy-link-for-slack");
 
+    // Then: The copied HTML contains the configured custom emoji.
     const html = await readClipboardHtml(page);
     expect(html).not.toBeNull();
     expect(html).toContain(":my_emoji:");
 
-    // Cleanup
+    // Cleanup: Reset the test-specific settings.
     await sw.evaluate(async () => {
       await chrome.storage.local.remove([
         "emojiNames",
@@ -261,13 +278,15 @@ test.describe("Popup settings page", () => {
     extensionId,
     context,
   }) => {
-    // Register a custom regex that matches GitHub's hostname
+    // Given: The popup settings page is open with a custom GitHub-matching entry.
     const popupPage = await context.newPage();
     await popupPage.goto(`chrome-extension://${extensionId}/popup.html`, {
       waitUntil: "domcontentloaded",
     });
 
     const regexInput = popupPage.locator("#regex-custom-1");
+
+    // When: A custom regex and emoji are entered for GitHub URLs.
     await regexInput.clear();
     await regexInput.fill("github\\.com");
 
@@ -277,20 +296,21 @@ test.describe("Popup settings page", () => {
 
     await popupPage.waitForTimeout(300);
 
-    // Visit a GitHub repo page (which would normally use the built-in :github: emoji)
+    // When: copy-link-for-slack is executed on a GitHub repo page.
     const page = await context.newPage();
     await page.goto("https://github.com/wintorse/copylink-dev", {
       waitUntil: "domcontentloaded",
     });
     await triggerCommand(sw, page, "copy-link-for-slack");
 
+    // Then: The custom emoji is used instead of the built-in GitHub emoji.
     const html = await readClipboardHtml(page);
     expect(html).not.toBeNull();
     // Custom regex should take priority: custom emoji appears, built-in :github: does not
     expect(html).toContain(":my_custom_emoji:");
     expect(html).not.toContain(":github:");
 
-    // Cleanup
+    // Cleanup: Reset the test-specific settings.
     await sw.evaluate(async () => {
       await chrome.storage.local.remove([
         "emojiNames",

--- a/tests/e2e/site-title.spec.ts
+++ b/tests/e2e/site-title.spec.ts
@@ -16,16 +16,23 @@ test.describe("Site-specific title formatting and emoji", () => {
     sw,
     context,
   }) => {
+    // Given: A GitHub pull request page is open.
     const page = await context.newPage();
     await page.goto("https://github.com/wintorse/copylink-dev/pull/52", {
       waitUntil: "domcontentloaded",
     });
+
+    // When: The copy-link command is executed.
     await triggerCommand(sw, page, "copy-link");
 
+    // Then: The copied text starts with the pull request number and title.
     const text = await readClipboardText(page);
     expect(text).toMatch(/^#52 .+/);
 
+    // When: The copy-link-for-slack command is executed.
     await triggerCommand(sw, page, "copy-link-for-slack");
+
+    // Then: The copied HTML contains the open pull request emoji.
     const html = await readClipboardHtml(page);
     expect(html).not.toBeNull();
     expect(html).toContain(":open_pull_request:");
@@ -35,6 +42,7 @@ test.describe("Site-specific title formatting and emoji", () => {
     sw,
     context,
   }) => {
+    // Given: Merged and open pull request emoji names are configured.
     await sw.evaluate(async () => {
       await chrome.storage.local.set({
         emojiNames: {
@@ -50,8 +58,10 @@ test.describe("Site-specific title formatting and emoji", () => {
     });
     await page.waitForSelector("header [data-status]", { timeout: 15_000 });
 
+    // When: The copy-link-for-slack command is executed on the merged PR.
     await triggerCommand(sw, page, "copy-link-for-slack");
 
+    // Then: The copied HTML contains only the merged pull request emoji.
     const html = await readClipboardHtml(page);
     expect(html).not.toBeNull();
     expect(html).toContain(":merged_pull_request:");
@@ -63,33 +73,47 @@ test.describe("Site-specific title formatting and emoji", () => {
   });
 
   test("GitHub Issue: title is #<number> <text>", async ({ sw, context }) => {
+    // Given: A GitHub issue page is open.
     const page = await context.newPage();
     await page.goto("https://github.com/wintorse/copylink-dev/issues/54", {
       waitUntil: "domcontentloaded",
     });
+
+    // When: The copy-link command is executed.
     await triggerCommand(sw, page, "copy-link");
 
+    // Then: The copied text starts with the issue number and title.
     const text = await readClipboardText(page);
     expect(text).toMatch(/^#54 .+/);
 
+    // When: The copy-link-for-slack command is executed.
     await triggerCommand(sw, page, "copy-link-for-slack");
+
+    // Then: The copied HTML contains the open issue emoji.
     const html = await readClipboardHtml(page);
     expect(html).not.toBeNull();
     expect(html).toContain(":open_issue:");
   });
 
   test("GitHub Repo: emoji is :github:", async ({ sw, context }) => {
+    // Given: A GitHub repository page is open.
     const page = await context.newPage();
     await page.goto("https://github.com/wintorse/copylink-dev", {
       waitUntil: "domcontentloaded",
     });
+
+    // When: The copy-link command is executed.
     await triggerCommand(sw, page, "copy-link");
 
+    // Then: The copied title references the repository.
     const text = await readClipboardText(page);
     // Title should reference the repo name
     expect(text).toContain("copylink-dev");
 
+    // When: The copy-link-for-slack command is executed.
     await triggerCommand(sw, page, "copy-link-for-slack");
+
+    // Then: The copied HTML uses the GitHub emoji and no issue-specific emoji.
     const html = await readClipboardHtml(page);
     expect(html).not.toBeNull();
     // Repo pages should use :github:, not PR/Issue emojis
@@ -106,6 +130,7 @@ test.describe("Site-specific title formatting and emoji", () => {
     sw,
     context,
   }) => {
+    // Given: A Jira issue page is open and its issue key has rendered.
     const page = await context.newPage();
     await page.goto(
       "https://jira.mongodb.org/projects/HIBERNATE/issues/HIBERNATE-77?filter=allopenissues",
@@ -114,12 +139,18 @@ test.describe("Site-specific title formatting and emoji", () => {
     // Jira may load content dynamically
     await page.waitForSelector("#key-val", { timeout: 15_000 });
 
+    // When: The copy-link command is executed.
     await triggerCommand(sw, page, "copy-link");
+
+    // Then: The copied text contains the Jira issue key and title.
     const text = await readClipboardText(page);
     expect(text).toContain("HIBERNATE-77");
     expect(text).toContain("Support HQL in / not in");
 
+    // When: The copy-link-for-slack command is executed.
     await triggerCommand(sw, page, "copy-link-for-slack");
+
+    // Then: The copied HTML contains the Jira emoji.
     const html = await readClipboardHtml(page);
     expect(html).not.toBeNull();
     expect(html).toContain(":jira:");
@@ -133,6 +164,7 @@ test.describe("Site-specific title formatting and emoji", () => {
     sw,
     context,
   }) => {
+    // Given: A mocked Redmine issue page returns the issue title structure.
     // redmine.openspace3d.com is a small, third-party-hosted Redmine
     // instance that is intermittently unreliable (slow responses / 503s),
     // which made this test flaky. Mock the response like the Asana/Backlog
@@ -159,12 +191,18 @@ test.describe("Site-specific title formatting and emoji", () => {
       waitUntil: "domcontentloaded",
     });
 
+    // When: The copy-link command is executed.
     await triggerCommand(sw, page, "copy-link");
+
+    // Then: The copied text contains the Redmine issue number and title.
     const text = await readClipboardText(page);
     expect(text).toContain("Feature #642");
     expect(text).toContain("OpenXR On Linux.");
 
+    // When: The copy-link-for-slack command is executed.
     await triggerCommand(sw, page, "copy-link-for-slack");
+
+    // Then: The copied HTML contains the Redmine ticket emoji.
     const html = await readClipboardHtml(page);
     expect(html).not.toBeNull();
     expect(html).toContain(":redmine_ticket:");
@@ -175,6 +213,7 @@ test.describe("Site-specific title formatting and emoji", () => {
   // ──────────────────────────────────────────────
 
   test("ReDoc: title is 法令本文取得API", async ({ sw, context }) => {
+    // Given: A ReDoc operation page is open and its active label has rendered.
     const page = await context.newPage();
     await page.goto(
       "https://laws.e-gov.go.jp/api/2/redoc/#tag/laws-api/operation/get-law_data",
@@ -183,11 +222,17 @@ test.describe("Site-specific title formatting and emoji", () => {
     // Wait for ReDoc to render the active label
     await page.waitForSelector("label[class*='active']", { timeout: 15_000 });
 
+    // When: The copy-link command is executed.
     await triggerCommand(sw, page, "copy-link");
+
+    // Then: The copied text contains the operation title.
     const text = await readClipboardText(page);
     expect(text).toContain("法令本文取得API");
 
+    // When: The copy-link-for-slack command is executed.
     await triggerCommand(sw, page, "copy-link-for-slack");
+
+    // Then: The copied HTML contains the Swagger emoji.
     const html = await readClipboardHtml(page);
     expect(html).not.toBeNull();
     expect(html).toContain(":swagger:");
@@ -201,6 +246,7 @@ test.describe("Site-specific title formatting and emoji", () => {
     sw,
     context,
   }) => {
+    // Given: A Google Sheets spreadsheet page is open and its title input exists.
     const page = await context.newPage();
     await page.goto(SHEETS_URL, { waitUntil: "load", timeout: 30_000 });
     // Wait for title input to be in the DOM (it may be hidden)
@@ -209,11 +255,17 @@ test.describe("Site-specific title formatting and emoji", () => {
       timeout: 15_000,
     });
 
+    // When: The copy-link command is executed.
     await triggerCommand(sw, page, "copy-link");
+
+    // Then: The copied text contains the spreadsheet title.
     const text = await readClipboardText(page);
     expect(text).toContain("テスト spreadsheet");
 
+    // When: The copy-link-for-slack command is executed.
     await triggerCommand(sw, page, "copy-link-for-slack");
+
+    // Then: The copied HTML contains the Google Sheets emoji.
     const html = await readClipboardHtml(page);
     expect(html).not.toBeNull();
     expect(html).toContain(":google_sheets:");
@@ -224,6 +276,7 @@ test.describe("Site-specific title formatting and emoji", () => {
   // ──────────────────────────────────────────────
 
   test("Google Docs: title is テスト document", async ({ sw, context }) => {
+    // Given: A Google Docs document page is open and its title input exists.
     const page = await context.newPage();
     await page.goto(
       "https://docs.google.com/document/d/1dnmPyKPXidbBweLnAkOLbvJpbgOMuft6LrtMoeLtjCg/edit",
@@ -234,11 +287,17 @@ test.describe("Site-specific title formatting and emoji", () => {
       timeout: 15_000,
     });
 
+    // When: The copy-link command is executed.
     await triggerCommand(sw, page, "copy-link");
+
+    // Then: The copied text contains the document title.
     const text = await readClipboardText(page);
     expect(text).toContain("テスト document");
 
+    // When: The copy-link-for-slack command is executed.
     await triggerCommand(sw, page, "copy-link-for-slack");
+
+    // Then: The copied HTML contains the Google Docs emoji.
     const html = await readClipboardHtml(page);
     expect(html).not.toBeNull();
     expect(html).toContain(":google_docs:");
@@ -252,6 +311,7 @@ test.describe("Site-specific title formatting and emoji", () => {
     sw,
     context,
   }) => {
+    // Given: A Google Slides presentation page is open and its title input exists.
     const page = await context.newPage();
     await page.goto(
       "https://docs.google.com/presentation/d/1LYg3VmFY4yBCI8ujhzTlMSBYLkv5b8W3sTQ8qTIJZtc/edit",
@@ -262,11 +322,17 @@ test.describe("Site-specific title formatting and emoji", () => {
       timeout: 15_000,
     });
 
+    // When: The copy-link command is executed.
     await triggerCommand(sw, page, "copy-link");
+
+    // Then: The copied text contains the presentation title.
     const text = await readClipboardText(page);
     expect(text).toContain("テスト presentation");
 
+    // When: The copy-link-for-slack command is executed.
     await triggerCommand(sw, page, "copy-link-for-slack");
+
+    // Then: The copied HTML contains the Google Slides emoji.
     const html = await readClipboardHtml(page);
     expect(html).not.toBeNull();
     expect(html).toContain(":google_slides:");
@@ -277,6 +343,7 @@ test.describe("Site-specific title formatting and emoji", () => {
   // ──────────────────────────────────────────────
 
   test("Google Drive: title is public folder", async ({ sw, context }) => {
+    // Given: A Google Drive folder page is open and its title has loaded.
     const page = await context.newPage();
     await page.goto(
       "https://drive.google.com/drive/folders/1Om4PwxNNjGDODM8EZXFP-aRHSL1NyJg0",
@@ -291,12 +358,18 @@ test.describe("Site-specific title formatting and emoji", () => {
       { timeout: 20_000 },
     );
 
+    // When: The copy-link command is executed.
     await triggerCommand(sw, page, "copy-link");
+
+    // Then: The copied text contains the folder title.
     const text = await readClipboardText(page);
     // Google Drive title = document.title with " - Google Drive" stripped
     expect(text).toContain("public folder");
 
+    // When: The copy-link-for-slack command is executed.
     await triggerCommand(sw, page, "copy-link-for-slack");
+
+    // Then: The copied HTML contains the Google Drive emoji.
     const html = await readClipboardHtml(page);
     expect(html).not.toBeNull();
     expect(html).toContain(":google_drive_2:");
@@ -310,6 +383,7 @@ test.describe("Site-specific title formatting and emoji", () => {
     sw,
     context,
   }) => {
+    // Given: A mocked Asana task page contains the task name in an aria-label.
     const page = await context.newPage();
     await page.route("https://app.asana.com/0/1234/5678", async (route) => {
       await route.fulfill({
@@ -324,12 +398,18 @@ test.describe("Site-specific title formatting and emoji", () => {
     await page.goto("https://app.asana.com/0/1234/5678", {
       waitUntil: "domcontentloaded",
     });
+
+    // When: The copy-link command is executed.
     await triggerCommand(sw, page, "copy-link");
 
+    // Then: The copied text is the Asana task title.
     const text = await readClipboardText(page);
     expect(text).toBe("My Asana Task");
 
+    // When: The copy-link-for-slack command is executed.
     await triggerCommand(sw, page, "copy-link-for-slack");
+
+    // Then: The copied HTML contains the Asana emoji.
     const html = await readClipboardHtml(page);
     expect(html).not.toBeNull();
     expect(html).toContain(":asana:");
@@ -343,6 +423,7 @@ test.describe("Site-specific title formatting and emoji", () => {
     sw,
     context,
   }) => {
+    // Given: A mocked Backlog issue page contains the issue title in its DOM selector.
     const page = await context.newPage();
     await page.route(
       "https://example.backlog.jp/view/PROJ-1",
@@ -362,12 +443,18 @@ test.describe("Site-specific title formatting and emoji", () => {
     await page.goto("https://example.backlog.jp/view/PROJ-1", {
       waitUntil: "domcontentloaded",
     });
+
+    // When: The copy-link command is executed.
     await triggerCommand(sw, page, "copy-link");
 
+    // Then: The copied text is the Backlog issue title.
     const text = await readClipboardText(page);
     expect(text).toBe("My Backlog Issue");
 
+    // When: The copy-link-for-slack command is executed.
     await triggerCommand(sw, page, "copy-link-for-slack");
+
+    // Then: The copied HTML contains the Backlog emoji.
     const html = await readClipboardHtml(page);
     expect(html).not.toBeNull();
     expect(html).toContain(":backlog:");

--- a/tests/e2e/toast.spec.ts
+++ b/tests/e2e/toast.spec.ts
@@ -40,10 +40,14 @@ test.describe("Toast notification", () => {
     sw,
     context,
   }) => {
+    // Given: An example.com page is open.
     const page = await context.newPage();
     await page.goto("https://example.com", { waitUntil: "domcontentloaded" });
+
+    // When: The copy-link command is executed.
     await triggerCommand(sw, page, "copy-link");
 
+    // Then: A non-empty toast is displayed in the extension's Shadow DOM.
     // Toast is rendered inside a Shadow DOM host element
     // const toastHost = page.locator("div").filter({
     //   has: page.locator(":scope"),
@@ -82,6 +86,7 @@ test.describe("Toast notification", () => {
     expect(toastText).not.toBeNull();
     expect(toastText?.length).toBeGreaterThan(0);
 
+    // Then: The toast is removed automatically after its display duration.
     // Wait for toast to be removed (~3s duration + 200ms fade)
     await page.waitForFunction(
       () => {
@@ -105,6 +110,7 @@ test.describe("Toast notification", () => {
     sw,
     context,
   }) => {
+    // Given: A mocked Google Sheets page has no available range information.
     const page = await context.newPage();
 
     // Mock a Google Sheets URL that serves a page WITHOUT #t-name-box.
@@ -124,8 +130,11 @@ test.describe("Toast notification", () => {
       "https://docs.google.com/spreadsheets/d/test-sheet-id/edit#gid=0",
       { waitUntil: "domcontentloaded" },
     );
+
+    // When: The copy-google-sheets-range command is executed.
     await triggerCommand(sw, page, "copy-google-sheets-range");
 
+    // Then: A localized failure toast is displayed.
     // Failure toast should appear
     const toastText = await page.evaluate(() => {
       const hosts = document.querySelectorAll("body > div");
@@ -143,6 +152,7 @@ test.describe("Toast notification", () => {
     expect(toastText).not.toBeNull();
     expect(sheetsRangeFailureMessages).toContain(toastText);
 
+    // Then: The failure toast is removed automatically.
     // Failure toast should also disappear automatically
     await page.waitForFunction(
       () => {

--- a/tests/e2e/toast.spec.ts
+++ b/tests/e2e/toast.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, triggerCommand } from "./fixtures";
+import { E2E_FIXTURE_URL, expect, test, triggerCommand } from "./fixtures";
 import { fileURLToPath } from "url";
 import { join } from "path";
 import { readFileSync } from "fs";
@@ -40,9 +40,9 @@ test.describe("Toast notification", () => {
     sw,
     context,
   }) => {
-    // Given: An example.com page is open.
+    // Given: The e2e fixture page is open.
     const page = await context.newPage();
-    await page.goto("https://example.com", { waitUntil: "domcontentloaded" });
+    await page.goto(E2E_FIXTURE_URL, { waitUntil: "domcontentloaded" });
 
     // When: The copy-link command is executed.
     await triggerCommand(sw, page, "copy-link");


### PR DESCRIPTION
resolves #122 
- Add descriptive comments (in Given-When-Then pattern) to test cases for clarity
- Update e2e tests to use wintorse.github.io instead of example.com because example.com is for use in documentation, not testing.